### PR TITLE
Add missing abilities that add types, immunity, resists and weaknesses

### DIFF
--- a/static/js/weakness.js
+++ b/static/js/weakness.js
@@ -119,6 +119,8 @@ const abilityAddingType = {
     "Turboblaze": "Fire",
     "Teravolt": "Electric",
     "Fairy Tale": "Fairy", //TODO ADD IT TO THE CALC TOO
+    "Aquatic Dweller": "Water",
+    "Metallic Jaw": "Steel",
 }
 
 export function abilitiesToAddedType(abis){
@@ -196,6 +198,16 @@ const abilityThatAddsImmunity = {
     "Mountaineer": ["Rock"],
     "Poison Absorb": ["Poison"],
     "Aerodynamics": ["Flying"],
+    "Well Baked Body": ["Fire"],
+    "Elemental Vortex": ["Fire", "Water"],
+    "Justified": ["Dark"],
+    "Ice Dew": ["Ice"],
+    "Earth Eater": ["Ground"],
+    "Hover": ["Ground"],
+    "Aerialist": ["Ground"],
+    "Imposing Wings": ["Ground"],
+    "Desolate Sun": ["Ground"],
+    "Reservoir": ["Water"],
 }
 
 const abilityThatAddsNormal = {
@@ -203,7 +215,6 @@ const abilityThatAddsNormal = {
 }
 
 const abilityThatAddsResist = {
-    "Well Baked Body": ["Fire"],
     "Water Bubble": ["Fire"],
     "Seaweed": ["Fire"],
     "Heatproof": ["Fire"],
@@ -213,11 +224,17 @@ const abilityThatAddsResist = {
     "Fossilized": ["Rock"],
     "Raw Wood": ["Grass"],
     "Water Compaction": ["Water"],
+    "Old Mariner": ["Fire"],
+    "Flame Bubble": ["Fire"],
+    "Deep Freeze": ["Fire"],
+    "Iron Giant": ["Fire"]
 }
 
 const abilityThatAddsWeakness = {
     "Fluffy": ["Fire"],
+    "Puffy": ["Fire"],
     "Liquified": ["Water"],
+    "Dry Skin": ["Fire"]
 }
 // misses things like Magma Armor or others that reduce by 35% like Filter
 // or Ice Scales or Fluffy for Physical or other damage

--- a/static/js/weakness.js
+++ b/static/js/weakness.js
@@ -118,9 +118,9 @@ const abilityAddingType = {
     "Aquatic": "Water",
     "Turboblaze": "Fire",
     "Teravolt": "Electric",
-    "Fairy Tale": "Fairy", //TODO ADD IT TO THE CALC TOO
+    "Fairy Tale": "Fairy",
     "Aquatic Dweller": "Water",
-    "Metallic Jaw": "Steel",
+    "Metallic Jaw": "Steel", //TODO ADD IT TO THE CALC TOO
 }
 
 export function abilitiesToAddedType(abis){
@@ -206,8 +206,10 @@ const abilityThatAddsImmunity = {
     "Hover": ["Ground"],
     "Aerialist": ["Ground"],
     "Imposing Wings": ["Ground"],
-    "Desolate Sun": ["Ground"],
+    "Desolate Sun": ["Ground", "Water"],
     "Reservoir": ["Water"],
+    "Desolate Land": ["Water"],
+    "Primordial Sea": ["Fire"],
 }
 
 const abilityThatAddsNormal = {

--- a/static/js/weakness.js
+++ b/static/js/weakness.js
@@ -236,7 +236,8 @@ const abilityThatAddsWeakness = {
     "Fluffy": ["Fire"],
     "Puffy": ["Fire"],
     "Liquified": ["Water"],
-    "Dry Skin": ["Fire"]
+    "Dry Skin": ["Fire"],
+    "Fluffiest": ["Fire"], // TODO: Handle 4x weakness
 }
 // misses things like Magma Armor or others that reduce by 35% like Filter
 // or Ice Scales or Fluffy for Physical or other damage


### PR DESCRIPTION
# PR Summary
Abilities that are a combination of other abilities (e.g. Elemental Vortex = Flash Fire + Water Absorb) are missing from the list of abilities that add types, immunities and resists. I also tried my best to add missing abilities that are supposed to be in these list.

### 1. `abilityAddingType` - Added 2 new abilities
- `"Aquatic Dweller": "Water"`
- `"Metallic Jaw": "Steel"`

### 2. `abilityThatAddsImmunity` - Added 14 new abilities
- `"Well Baked Body": ["Fire"]`
- `"Elemental Vortex": ["Fire", "Water"]`
- `"Justified": ["Dark"]`
- `"Ice Dew": ["Ice"]`
- `"Earth Eater": ["Ground"]`
- `"Hover": ["Ground"]`
- `"Aerialist": ["Ground"]`
- `"Imposing Wings": ["Ground"]`
- `"Desolate Sun": ["Ground"]`
- `"Reservoir": ["Water"]`
- `"Desolate Land": ["Water"]`
- `"Primordial Sea": ["Fire"]`

### 3. `abilityThatAddsResist` - Updated entries
**Removed:**
- `"Well Baked Body": ["Fire"]` (this was wrong and moved to immunity)

**Added:**
- `"Old Mariner": ["Fire"]`
- `"Flame Bubble": ["Fire"]`
- `"Deep Freeze": ["Fire"]`
- `"Iron Giant": ["Fire"]`

### 4. `abilityThatAddsWeakness` - Added 3 new abilities
- `"Puffy": ["Fire"]`
- `"Dry Skin": ["Fire"]`
- `"Fluffiest": ["Fire"]`

> [!NOTE]
> Fluffiest makes the user take 4x damage to fire, I left a TODO to handle that.