### PR TITLE
feat: Add type defense calculator tab

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -1088,4 +1088,186 @@ a:hover{
     z-index: 20;
 }
 
+/* Type Defense Calculator */
+#typecalc-data{
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    overflow: auto;
+}
+.typecalc-controls{
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+}
+.typecalc-row{
+    display: flex;
+    width: 100%;
+    font-size: 2vmax;
+    align-items: center;
+}
+.typecalc-row-label{
+    width: 5em;
+    min-width: 5em;
+    text-align: center;
+    padding: 0.2em 0;
+}
+.typecalc-row-content{
+    flex-grow: 1;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.3em;
+    padding: 0.2em 0.5em;
+}
+.tc-dropdown-wrap{
+    position: relative;
+    flex: 1;
+    min-width: 5em;
+}
+.tc-dropdown-btn{
+    width: 100%;
+    font-family: inherit;
+    font-size: 0.9em;
+    padding: 0.2em 0.3em;
+    background-color: var(--btnNActive);
+    color: var(--font-color);
+    border: solid var(--selActive) 1px;
+    cursor: pointer;
+    text-align: center;
+    outline: none;
+    user-select: none;
+}
+.tc-dropdown-btn:hover{
+    background-color: var(--selHover);
+}
+.tc-dropdown-list{
+    position: absolute;
+    z-index: 10;
+    width: 100%;
+    max-height: 15em;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+}
+.tc-dropdown-list > div{
+    cursor: pointer;
+    background-color: var(--selNActive);
+    text-align: center;
+    width: 100%;
+    border: solid var(--shadow) 1px;
+    border-top: 0;
+    padding: 0.15em 0;
+    font-family: inherit;
+    font-size: 0.85em;
+}
+.tc-dropdown-list > div:first-child{
+    border-top: solid var(--shadow) 1px;
+}
+.tc-dropdown-list > div:hover{
+    background-color: var(--selHover);
+}
+.tc-dropdown-list > div.tc-dropdown-selected{
+    background-color: var(--selActive);
+}
+.typecalc-result{
+    display: flex;
+    flex-direction: column;
+    flex-grow: 1;
+}
+.typecalc-info-row{
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.3em;
+    padding: 0.3em 0.5em;
+    background-color: var(--colorB);
+    font-size: 1.5vmax;
+    align-items: center;
+}
+.typecalc-info-row .type{
+    padding: 0.1em 0.5em;
+}
+.typecalc-abi-info{
+    display: flex;
+    width: 100%;
+    font-size: 2vmax;
+}
+.typecalc-abi-name{
+    width: 9em;
+    min-width: 9em;
+    text-align: center;
+}
+.typecalc-abi-effects{
+    padding-left: 1%;
+    flex-grow: 1;
+}
+.typecalc-dmg-mods{
+    display: flex;
+    width: 100%;
+}
+.typecalc-dmg-mod{
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 0.2em 0;
+    font-size: 1.5vmax;
+}
+.typecalc-dmg-mod:nth-child(1){
+    background-color: var(--colorA);
+}
+.typecalc-dmg-mod:nth-child(2){
+    background-color: var(--colorB);
+}
+.typecalc-dmg-mod:nth-child(3){
+    background-color: var(--colorA);
+}
+.typecalc-dmg-label{
+    font-size: 0.8em;
+    opacity: 0.7;
+}
+.typecalc-dmg-val{
+    font-size: 1.1em;
+}
+.typecalc-dmg-val.resist{
+    color: var(--positive);
+}
+.typecalc-coverage-row{
+    text-align: center;
+    width: 100%;
+    display: flex;
+    overflow-wrap: break-word;
+}
+.typecalc-coverage-mul{
+    width: 2em;
+    min-width: 2em;
+    background-color: var(--colorA);
+    box-shadow: inset 0 0 1vmax var(--shadow);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+.typecalc-coverage-list{
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    font-size: 1.3vmax;
+}
+.typecalc-coverage-list > div{
+    display: flex;
+    width: 3em;
+}
+@media (orientation: portrait) {
+    .typecalc-coverage-list{
+        font-size: 2.5vmax;
+    }
+    .typecalc-coverage-mul{
+        width: 2.5em;
+        min-width: 2.5em;
+        font-size: 2.5vmax;
+    }
+    .typecalc-coverage-list > div{
+        width: 3.5em;
+    }
+}
+
 

--- a/static/index.html
+++ b/static/index.html
@@ -245,6 +245,50 @@
                 <!--button id="filter-alphabethically">Filter Alphabethically</button-->
                 <div id="abis-list">
                 </div>
+                <div id="typecalc-data" style="display: none;">
+                    <div class="typecalc-controls">
+                        <div class="typecalc-row colorA">
+                            <div class="typecalc-row-label">Types</div>
+                            <div class="typecalc-row-content">
+                                <div class="tc-dropdown-wrap">
+                                    <input type="text" class="tc-dropdown-btn" id="typecalc-type1" value="Normal" autocomplete="off">
+                                    <div class="tc-dropdown-list" style="display:none;"></div>
+                                </div>
+                                <div class="tc-dropdown-wrap">
+                                    <input type="text" class="tc-dropdown-btn" id="typecalc-type2" value="-- None --" autocomplete="off">
+                                    <div class="tc-dropdown-list" style="display:none;"></div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="typecalc-row colorB">
+                            <div class="typecalc-row-label">Ability</div>
+                            <div class="typecalc-row-content">
+                                <div class="tc-dropdown-wrap">
+                                    <input type="text" class="tc-dropdown-btn" id="typecalc-abi0" value="-- None --" autocomplete="off">
+                                    <div class="tc-dropdown-list" style="display:none;"></div>
+                                </div>
+                                <div class="tc-dropdown-wrap">
+                                    <input type="text" class="tc-dropdown-btn" id="typecalc-abi1" value="-- None --" autocomplete="off">
+                                    <div class="tc-dropdown-list" style="display:none;"></div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="typecalc-row colorA">
+                            <div class="typecalc-row-label">Ability</div>
+                            <div class="typecalc-row-content">
+                                <div class="tc-dropdown-wrap">
+                                    <input type="text" class="tc-dropdown-btn" id="typecalc-abi2" value="-- None --" autocomplete="off">
+                                    <div class="tc-dropdown-list" style="display:none;"></div>
+                                </div>
+                                <div class="tc-dropdown-wrap">
+                                    <input type="text" class="tc-dropdown-btn" id="typecalc-abi3" value="-- None --" autocomplete="off">
+                                    <div class="tc-dropdown-list" style="display:none;"></div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div id="typecalc-result" class="typecalc-result"></div>
+                </div>
             </div>
             <div id="panel-moves" class="panel">
                 <div id="moves-list" class="data-list">
@@ -366,9 +410,8 @@
                 <span class="small-select interactible">Builder</span>
             </div>
             <div class="side-btn btn-n-active interactible" id="btn-abis">
-                <span>
-                    Abilities
-                </span>
+                <span class="big-select interactible">Abilities</span>
+                <span class="small-select interactible">Calc</span>
             </div>
             <div class="side-btn btn-n-active interactible" id="btn-moves">
                 <span>Moves</span>

--- a/static/js/data/defensiveAbilities.js
+++ b/static/js/data/defensiveAbilities.js
@@ -1,0 +1,1372 @@
+export default {
+  "effects": {
+    "Water Bubble": {
+      "resists": [
+        {
+          "damageSource": "Fire",
+          "multiplier": 0.5,
+          "resistType": "resist"
+        }
+      ]
+    },
+    "Heatproof": {
+      "resists": [
+        {
+          "damageSource": "Fire",
+          "multiplier": 0.5,
+          "resistType": "resist"
+        }
+      ]
+    },
+    "Thick Fat": {
+      "resists": [
+        {
+          "damageSource": "Fire",
+          "multiplier": 0.5,
+          "resistType": "resist"
+        },
+        {
+          "damageSource": "Ice",
+          "multiplier": 0.5,
+          "resistType": "resist"
+        }
+      ]
+    },
+    "Immunity": {
+      "resists": [
+        {
+          "damageSource": "Poison",
+          "multiplier": 0.5,
+          "resistType": "resist"
+        }
+      ]
+    },
+    "Fossilized": {
+      "resists": [
+        {
+          "damageSource": "Rock",
+          "multiplier": 0.5,
+          "resistType": "resist"
+        }
+      ]
+    },
+    "Raw Wood": {
+      "resists": [
+        {
+          "damageSource": "Grass",
+          "multiplier": 0.5,
+          "resistType": "resist"
+        }
+      ]
+    },
+    "Water Compaction": {
+      "resists": [
+        {
+          "damageSource": "Water",
+          "multiplier": 0.5,
+          "resistType": "resist",
+          "bonusEffect": "+2 Def"
+        }
+      ]
+    },
+    "Old Mariner": {
+      "resists": [
+        {
+          "damageSource": "Fire",
+          "multiplier": 0.5,
+          "resistType": "resist"
+        }
+      ]
+    },
+    "Flame Bubble": {
+      "resists": [
+        {
+          "damageSource": "Fire",
+          "multiplier": 0.5,
+          "resistType": "resist"
+        }
+      ]
+    },
+    "Deep Freeze": {
+      "resists": [
+        {
+          "damageSource": "Fire",
+          "multiplier": 0.5,
+          "resistType": "resist"
+        }
+      ]
+    },
+    "Thermal Entropy": {
+      "resists": [
+        {
+          "damageSource": "Fire",
+          "multiplier": 0.5,
+          "resistType": "resist"
+        }
+      ]
+    },
+    "Strong Foundation": {
+      "resists": [
+        {
+          "damageSource": "Water",
+          "multiplier": 0.5,
+          "resistType": "resist"
+        },
+        {
+          "damageSource": "Ground",
+          "multiplier": 0.5,
+          "resistType": "resist"
+        }
+      ]
+    },
+    "Sumo Guard": {
+      "resists": [
+        {
+          "damageSource": "Fire",
+          "multiplier": 0.5,
+          "resistType": "resist"
+        },
+        {
+          "damageSource": "Ice",
+          "multiplier": 0.5,
+          "resistType": "resist"
+        }
+      ]
+    },
+    "Tummyache": {
+      "resists": [
+        {
+          "damageSource": "Fire",
+          "multiplier": 0.5,
+          "resistType": "resist"
+        },
+        {
+          "damageSource": "Ice",
+          "multiplier": 0.5,
+          "resistType": "resist"
+        }
+      ]
+    },
+    "Purifying Salt": {
+      "resists": [
+        {
+          "damageSource": "Ghost",
+          "multiplier": 0.5,
+          "resistType": "resist"
+        }
+      ]
+    },
+    "Heavy Metal": {
+      "resists": [
+        {
+          "damageSource": "Ghost",
+          "multiplier": 0.5,
+          "resistType": "resist"
+        },
+        {
+          "damageSource": "Dark",
+          "multiplier": 0.5,
+          "resistType": "resist"
+        }
+      ]
+    },
+    "Aegis Ward": {
+      "resists": [
+        {
+          "damageSource": "Dark",
+          "multiplier": 0.5,
+          "resistType": "resist"
+        },
+        {
+          "damageSource": "Ghost",
+          "multiplier": 0.5,
+          "resistType": "resist"
+        },
+        {
+          "damageSource": "Psychic",
+          "multiplier": 0.5,
+          "resistType": "resist"
+        }
+      ]
+    },
+    "Elemental Aegis": {
+      "resists": [
+        {
+          "damageSource": "Fire",
+          "multiplier": 0.5,
+          "resistType": "resist"
+        },
+        {
+          "damageSource": "Electric",
+          "multiplier": 0.5,
+          "resistType": "resist"
+        },
+        {
+          "damageSource": "Water",
+          "multiplier": 0.5,
+          "resistType": "resist"
+        }
+      ]
+    },
+    "Magma Armor": {
+      "resists": [
+        {
+          "damageSource": "Water",
+          "multiplier": 0.5,
+          "resistType": "resist"
+        },
+        {
+          "damageSource": "Ice",
+          "multiplier": 0.5,
+          "resistType": "resist"
+        }
+      ]
+    },
+    "Hyper Cleanse": {
+      "resists": [
+        {
+          "damageSource": "Poison",
+          "multiplier": 0.5,
+          "resistType": "resist"
+        }
+      ]
+    },
+    "Thick Blubber": {
+      "resists": [
+        {
+          "damageSource": "Fire",
+          "multiplier": 0.25,
+          "resistType": "resist"
+        },
+        {
+          "damageSource": "Ice",
+          "multiplier": 0.25,
+          "resistType": "resist"
+        }
+      ]
+    },
+    "Dry Skin": {
+      "resists": [
+        {
+          "damageSource": "Water",
+          "multiplier": 0,
+          "resistType": "immune",
+          "bonusEffect": "heals from Water"
+        },
+        {
+          "damageSource": "Fire",
+          "multiplier": 2,
+          "resistType": "weakness"
+        }
+      ]
+    },
+    "Iron Giant": {
+      "resists": [
+        {
+          "damageSource": "Fire",
+          "multiplier": 0.5,
+          "resistType": "resist"
+        },
+        {
+          "damageSource": "Physical",
+          "multiplier": 0.8,
+          "resistType": "resist"
+        },
+        {
+          "damageSource": "Special",
+          "multiplier": 0.8,
+          "resistType": "resist"
+        },
+        {
+          "damageSource": "Contact",
+          "multiplier": 0.8,
+          "resistType": "resist"
+        }
+      ]
+    },
+    "Droideka": {
+      "resists": [
+        {
+          "damageSource": "Fire",
+          "multiplier": 0.5,
+          "resistType": "resist"
+        },
+        {
+          "damageSource": "Physical",
+          "multiplier": 0.8,
+          "resistType": "resist"
+        },
+        {
+          "damageSource": "Special",
+          "multiplier": 0.8,
+          "resistType": "resist"
+        },
+        {
+          "damageSource": "Contact",
+          "multiplier": 0.8,
+          "resistType": "resist"
+        }
+      ]
+    },
+    "Fluffy": {
+      "resists": [
+        {
+          "damageSource": "Fire",
+          "multiplier": 2,
+          "resistType": "weakness"
+        },
+        {
+          "damageSource": "Contact",
+          "multiplier": 0.5,
+          "resistType": "resist"
+        }
+      ]
+    },
+    "Puffy": {
+      "resists": [
+        {
+          "damageSource": "Fire",
+          "multiplier": 2,
+          "resistType": "weakness"
+        },
+        {
+          "damageSource": "Contact",
+          "multiplier": 0.5,
+          "resistType": "resist"
+        }
+      ]
+    },
+    "Liquified": {
+      "resists": [
+        {
+          "damageSource": "Water",
+          "multiplier": 2,
+          "resistType": "weakness"
+        },
+        {
+          "damageSource": "Contact",
+          "multiplier": 0.5,
+          "resistType": "resist"
+        }
+      ]
+    },
+    "Massive Pelt": {
+      "resists": [
+        {
+          "damageSource": "Fire",
+          "multiplier": 2,
+          "resistType": "weakness"
+        },
+        {
+          "damageSource": "Contact",
+          "multiplier": 0.5,
+          "resistType": "resist"
+        }
+      ]
+    },
+    "Fluffiest": {
+      "resists": [
+        {
+          "damageSource": "Fire",
+          "multiplier": 4,
+          "resistType": "weakness"
+        },
+        {
+          "damageSource": "Contact",
+          "multiplier": 0.25,
+          "resistType": "resist"
+        }
+      ]
+    },
+    "Fur Coat": {
+      "resists": [
+        {
+          "damageSource": "Physical",
+          "multiplier": 0.5,
+          "resistType": "resist"
+        }
+      ]
+    },
+    "Apple Enlightenment": {
+      "resists": [
+        {
+          "damageSource": "Physical",
+          "multiplier": 0.5,
+          "resistType": "resist"
+        }
+      ]
+    },
+    "Prismatic Fur": {
+      "resists": [
+        {
+          "damageSource": "Physical",
+          "multiplier": 0.5,
+          "resistType": "resist"
+        },
+        {
+          "damageSource": "Special",
+          "multiplier": 0.5,
+          "resistType": "resist"
+        }
+      ]
+    },
+    "Ice Scales": {
+      "resists": [
+        {
+          "damageSource": "Special",
+          "multiplier": 0.5,
+          "resistType": "resist"
+        }
+      ]
+    },
+    "Fire Scales": {
+      "resists": [
+        {
+          "damageSource": "Special",
+          "multiplier": 0.5,
+          "resistType": "resist"
+        }
+      ]
+    },
+    "Rainbow Scales": {
+      "resists": [
+        {
+          "damageSource": "Special",
+          "multiplier": 0.5,
+          "resistType": "resist"
+        }
+      ]
+    },
+    "Ice Plumes": {
+      "resists": [
+        {
+          "damageSource": "Special",
+          "multiplier": 0.5,
+          "resistType": "resist"
+        }
+      ]
+    },
+    "Prism Scales": {
+      "resists": [
+        {
+          "damageSource": "Special",
+          "multiplier": 0.7,
+          "resistType": "resist"
+        }
+      ]
+    },
+    "Dead Bark": {
+      "resists": [
+        {
+          "damageSource": "Physical",
+          "multiplier": 0.85,
+          "resistType": "resist"
+        },
+        {
+          "damageSource": "Special",
+          "multiplier": 0.85,
+          "resistType": "resist"
+        },
+        {
+          "damageSource": "Contact",
+          "multiplier": 0.85,
+          "resistType": "resist"
+        }
+      ],
+      "addedType": "Ghost"
+    },
+    "Rock Armor": {
+      "resists": [
+        {
+          "damageSource": "Physical",
+          "multiplier": 0.9,
+          "resistType": "resist"
+        },
+        {
+          "damageSource": "Special",
+          "multiplier": 0.9,
+          "resistType": "resist"
+        },
+        {
+          "damageSource": "Contact",
+          "multiplier": 0.9,
+          "resistType": "resist"
+        }
+      ],
+      "addedType": "Rock"
+    },
+    "Battle Armor": {
+      "resists": [
+        {
+          "damageSource": "Physical",
+          "multiplier": 0.8,
+          "resistType": "resist"
+        },
+        {
+          "damageSource": "Special",
+          "multiplier": 0.8,
+          "resistType": "resist"
+        },
+        {
+          "damageSource": "Contact",
+          "multiplier": 0.8,
+          "resistType": "resist"
+        }
+      ]
+    },
+    "Shell Armor": {
+      "resists": [
+        {
+          "damageSource": "Physical",
+          "multiplier": 0.8,
+          "resistType": "resist"
+        },
+        {
+          "damageSource": "Special",
+          "multiplier": 0.8,
+          "resistType": "resist"
+        },
+        {
+          "damageSource": "Contact",
+          "multiplier": 0.8,
+          "resistType": "resist"
+        }
+      ]
+    },
+    "Dream State": {
+      "resists": [
+        {
+          "damageSource": "Physical",
+          "multiplier": 0.8,
+          "resistType": "resist"
+        },
+        {
+          "damageSource": "Special",
+          "multiplier": 0.8,
+          "resistType": "resist"
+        },
+        {
+          "damageSource": "Contact",
+          "multiplier": 0.8,
+          "resistType": "resist"
+        }
+      ]
+    },
+    "Crust Coat": {
+      "resists": [
+        {
+          "damageSource": "Physical",
+          "multiplier": 0.8,
+          "resistType": "resist"
+        },
+        {
+          "damageSource": "Special",
+          "multiplier": 0.8,
+          "resistType": "resist"
+        },
+        {
+          "damageSource": "Contact",
+          "multiplier": 0.8,
+          "resistType": "resist"
+        }
+      ]
+    },
+    "Parry": {
+      "resists": [
+        {
+          "damageSource": "Physical",
+          "multiplier": 0.8,
+          "resistType": "resist"
+        },
+        {
+          "damageSource": "Special",
+          "multiplier": 0.8,
+          "resistType": "resist"
+        },
+        {
+          "damageSource": "Contact",
+          "multiplier": 0.8,
+          "resistType": "resist"
+        }
+      ]
+    },
+    "Deflect": {
+      "resists": [
+        {
+          "damageSource": "Physical",
+          "multiplier": 0.8,
+          "resistType": "resist"
+        },
+        {
+          "damageSource": "Special",
+          "multiplier": 0.8,
+          "resistType": "resist"
+        },
+        {
+          "damageSource": "Contact",
+          "multiplier": 0.8,
+          "resistType": "resist"
+        }
+      ]
+    },
+    "Feathercoat": {
+      "resists": [
+        {
+          "damageSource": "Physical",
+          "multiplier": 0.9,
+          "resistType": "resist"
+        },
+        {
+          "damageSource": "Special",
+          "multiplier": 0.9,
+          "resistType": "resist"
+        },
+        {
+          "damageSource": "Contact",
+          "multiplier": 0.9,
+          "resistType": "resist"
+        }
+      ]
+    },
+    "Mucus Membrane": {
+      "resists": [
+        {
+          "damageSource": "Physical",
+          "multiplier": 0.7,
+          "resistType": "resist"
+        },
+        {
+          "damageSource": "Special",
+          "multiplier": 0.7,
+          "resistType": "resist"
+        },
+        {
+          "damageSource": "Contact",
+          "multiplier": 0.7,
+          "resistType": "resist"
+        }
+      ]
+    },
+    "Faraday Cage": {
+      "resists": [
+        {
+          "damageSource": "Physical",
+          "multiplier": 0.8,
+          "resistType": "resist"
+        },
+        {
+          "damageSource": "Special",
+          "multiplier": 0.8,
+          "resistType": "resist"
+        },
+        {
+          "damageSource": "Contact",
+          "multiplier": 0.8,
+          "resistType": "resist"
+        }
+      ]
+    },
+    "Toxic Shell": {
+      "resists": [
+        {
+          "damageSource": "Physical",
+          "multiplier": 0.8,
+          "resistType": "resist"
+        },
+        {
+          "damageSource": "Special",
+          "multiplier": 0.8,
+          "resistType": "resist"
+        },
+        {
+          "damageSource": "Contact",
+          "multiplier": 0.8,
+          "resistType": "resist"
+        }
+      ]
+    },
+    "Shattered Armor": {
+      "resists": [
+        {
+          "damageSource": "Physical",
+          "multiplier": 0.8,
+          "resistType": "resist"
+        },
+        {
+          "damageSource": "Special",
+          "multiplier": 0.8,
+          "resistType": "resist"
+        },
+        {
+          "damageSource": "Contact",
+          "multiplier": 0.8,
+          "resistType": "resist"
+        }
+      ]
+    },
+    "Fortress": {
+      "resists": [
+        {
+          "damageSource": "SE",
+          "multiplier": 0.65,
+          "resistType": "resist"
+        },
+        {
+          "damageSource": "Physical",
+          "multiplier": 0.8,
+          "resistType": "resist"
+        },
+        {
+          "damageSource": "Special",
+          "multiplier": 0.8,
+          "resistType": "resist"
+        },
+        {
+          "damageSource": "Contact",
+          "multiplier": 0.8,
+          "resistType": "resist"
+        }
+      ]
+    },
+    "Filter": {
+      "resists": [
+        {
+          "damageSource": "SE",
+          "multiplier": 0.65,
+          "resistType": "resist"
+        }
+      ]
+    },
+    "Solid Rock": {
+      "resists": [
+        {
+          "damageSource": "SE",
+          "multiplier": 0.65,
+          "resistType": "resist"
+        }
+      ]
+    },
+    "Prism Armor": {
+      "resists": [
+        {
+          "damageSource": "SE",
+          "multiplier": 0.65,
+          "resistType": "resist"
+        }
+      ]
+    },
+    "Permafrost": {
+      "resists": [
+        {
+          "damageSource": "SE",
+          "multiplier": 0.65,
+          "resistType": "resist"
+        }
+      ]
+    },
+    "Thick Skin": {
+      "resists": [
+        {
+          "damageSource": "SE",
+          "multiplier": 0.65,
+          "resistType": "resist"
+        }
+      ]
+    },
+    "Flame Shield": {
+      "resists": [
+        {
+          "damageSource": "SE",
+          "multiplier": 0.65,
+          "resistType": "resist"
+        }
+      ]
+    },
+    "Primal Armor": {
+      "resists": [
+        {
+          "damageSource": "SE",
+          "multiplier": 0.5,
+          "resistType": "resist"
+        }
+      ]
+    },
+    "Refrigerator": {
+      "resists": [
+        {
+          "damageSource": "SE",
+          "multiplier": 0.65,
+          "resistType": "resist"
+        }
+      ]
+    },
+    "Steelworker": {
+      "conditionalResistances": [
+        {
+          "condition": {
+            "type": "type",
+            "value": "Steel"
+          },
+          "resistance": [
+            {
+              "damageSource": "Ghost",
+              "multiplier": 0.5,
+              "resistType": "resist"
+            },
+            {
+              "damageSource": "Dark",
+              "multiplier": 0.5,
+              "resistType": "resist"
+            }
+          ]
+        }
+      ]
+    },
+    "Seaweed": {
+      "conditionalResistances": [
+        {
+          "condition": {
+            "type": "type",
+            "value": "Grass"
+          },
+          "resistance": [
+            {
+              "damageSource": "Fire",
+              "multiplier": 0.5,
+              "resistType": "resist"
+            }
+          ]
+        }
+      ]
+    },
+    "Sand Guard": {
+      "conditionalResistances": [
+        {
+          "condition": {
+            "type": "weather",
+            "value": "Sand"
+          },
+          "resistance": [
+            {
+              "damageSource": "Special",
+              "multiplier": 0.5,
+              "resistType": "resist"
+            }
+          ]
+        }
+      ]
+    },
+    "Sun Basking": {
+      "conditionalResistances": [
+        {
+          "condition": {
+            "type": "weather",
+            "value": "Sun"
+          },
+          "resistance": [
+            {
+              "damageSource": "Physical",
+              "multiplier": 0.5,
+              "resistType": "resist"
+            }
+          ]
+        }
+      ]
+    },
+    "Christmas Spirit": {
+      "conditionalResistances": [
+        {
+          "condition": {
+            "type": "weather",
+            "value": "Hail"
+          },
+          "resistance": [
+            {
+              "damageSource": "Physical",
+              "multiplier": 0.5,
+              "resistType": "resist"
+            },
+            {
+              "damageSource": "Special",
+              "multiplier": 0.5,
+              "resistType": "resist"
+            },
+            {
+              "damageSource": "Contact",
+              "multiplier": 0.5,
+              "resistType": "resist"
+            }
+          ]
+        }
+      ]
+    },
+    "Flash Fire": {
+      "resists": [
+        {
+          "damageSource": "Fire",
+          "multiplier": 0,
+          "resistType": "immune",
+          "bonusEffect": "x1.5 Fire moves after hit"
+        }
+      ]
+    },
+    "Sap Sipper": {
+      "resists": [
+        {
+          "damageSource": "Grass",
+          "multiplier": 0,
+          "resistType": "immune",
+          "bonusEffect": "redirects, +Atk"
+        }
+      ]
+    },
+    "Volt Absorb": {
+      "resists": [
+        {
+          "damageSource": "Electric",
+          "multiplier": 0,
+          "resistType": "immune",
+          "bonusEffect": "heals 25% HP"
+        }
+      ]
+    },
+    "Lightning Rod": {
+      "resists": [
+        {
+          "damageSource": "Electric",
+          "multiplier": 0,
+          "resistType": "immune",
+          "bonusEffect": "redirects, +Atk"
+        }
+      ]
+    },
+    "Motor Drive": {
+      "resists": [
+        {
+          "damageSource": "Electric",
+          "multiplier": 0,
+          "resistType": "immune",
+          "bonusEffect": "+Speed"
+        }
+      ]
+    },
+    "Water Absorb": {
+      "resists": [
+        {
+          "damageSource": "Water",
+          "multiplier": 0,
+          "resistType": "immune",
+          "bonusEffect": "heals 25% HP"
+        }
+      ]
+    },
+    "Storm Drain": {
+      "resists": [
+        {
+          "damageSource": "Water",
+          "multiplier": 0,
+          "resistType": "immune",
+          "bonusEffect": "redirects, +Atk"
+        }
+      ]
+    },
+    "Evaporate": {
+      "resists": [
+        {
+          "damageSource": "Water",
+          "multiplier": 0,
+          "resistType": "immune",
+          "bonusEffect": "sets Mist"
+        }
+      ]
+    },
+    "Levitate": {
+      "resists": [
+        {
+          "damageSource": "Ground",
+          "multiplier": 0,
+          "resistType": "immune"
+        }
+      ]
+    },
+    "Dragonfly": {
+      "resists": [
+        {
+          "damageSource": "Ground",
+          "multiplier": 0,
+          "resistType": "immune"
+        }
+      ],
+      "addedType": "Dragon"
+    },
+    "Mountaineer": {
+      "resists": [
+        {
+          "damageSource": "Rock",
+          "multiplier": 0,
+          "resistType": "immune"
+        }
+      ]
+    },
+    "Poison Absorb": {
+      "resists": [
+        {
+          "damageSource": "Poison",
+          "multiplier": 0,
+          "resistType": "immune",
+          "bonusEffect": "redirects, heals 25% HP"
+        }
+      ]
+    },
+    "Aerodynamics": {
+      "resists": [
+        {
+          "damageSource": "Flying",
+          "multiplier": 0,
+          "resistType": "immune",
+          "bonusEffect": "+Speed"
+        }
+      ]
+    },
+    "Well Baked Body": {
+      "resists": [
+        {
+          "damageSource": "Fire",
+          "multiplier": 0,
+          "resistType": "immune",
+          "bonusEffect": "+Def sharply"
+        }
+      ]
+    },
+    "Elemental Vortex": {
+      "resists": [
+        {
+          "damageSource": "Fire",
+          "multiplier": 0,
+          "resistType": "immune",
+          "bonusEffect": "Fire: x1.5 Fire moves | Water: heals 25% HP"
+        },
+        {
+          "damageSource": "Water",
+          "multiplier": 0,
+          "resistType": "immune"
+        }
+      ]
+    },
+    "Justified": {
+      "resists": [
+        {
+          "damageSource": "Dark",
+          "multiplier": 0,
+          "resistType": "immune",
+          "bonusEffect": "+Atk"
+        }
+      ]
+    },
+    "Ice Dew": {
+      "resists": [
+        {
+          "damageSource": "Ice",
+          "multiplier": 0,
+          "resistType": "immune",
+          "bonusEffect": "redirects, +Atk"
+        }
+      ]
+    },
+    "Earth Eater": {
+      "resists": [
+        {
+          "damageSource": "Ground",
+          "multiplier": 0,
+          "resistType": "immune",
+          "bonusEffect": "heals 25% HP"
+        }
+      ]
+    },
+    "Hover": {
+      "resists": [
+        {
+          "damageSource": "Ground",
+          "multiplier": 0,
+          "resistType": "immune"
+        }
+      ],
+      "addedType": "Psychic"
+    },
+    "Aerialist": {
+      "resists": [
+        {
+          "damageSource": "Ground",
+          "multiplier": 0,
+          "resistType": "immune"
+        }
+      ]
+    },
+    "Imposing Wings": {
+      "resists": [
+        {
+          "damageSource": "Ground",
+          "multiplier": 0,
+          "resistType": "immune"
+        }
+      ]
+    },
+    "Desolate Sun": {
+      "resists": [
+        {
+          "damageSource": "Ground",
+          "multiplier": 0,
+          "resistType": "immune",
+          "bonusEffect": "heals 25% HP"
+        }
+      ],
+      "conditionalResistances": [
+        {
+          "condition": {
+            "type": "weather",
+            "value": "Sun"
+          },
+          "resistance": [
+            {
+              "damageSource": "Water",
+              "multiplier": 0,
+              "resistType": "immune"
+            }
+          ]
+        }
+      ]
+    },
+    "Reservoir": {
+      "resists": [
+        {
+          "damageSource": "Water",
+          "multiplier": 0,
+          "resistType": "immune",
+          "bonusEffect": "Water: heals 25% HP, redirects"
+        }
+      ]
+    },
+    "Desolate Land": {
+      "conditionalResistances": [
+        {
+          "condition": {
+            "type": "weather",
+            "value": "Sun"
+          },
+          "resistance": [
+            {
+              "damageSource": "Water",
+              "multiplier": 0,
+              "resistType": "immune"
+            }
+          ]
+        }
+      ]
+    },
+    "Primordial Sea": {
+      "conditionalResistances": [
+        {
+          "condition": {
+            "type": "weather",
+            "value": "Rain"
+          },
+          "resistance": [
+            {
+              "damageSource": "Fire",
+              "multiplier": 0,
+              "resistType": "immune"
+            }
+          ]
+        }
+      ]
+    },
+    "Fey Flight": {
+      "resists": [
+        {
+          "damageSource": "Ground",
+          "multiplier": 0,
+          "resistType": "immune"
+        }
+      ],
+      "addedType": "Fairy"
+    },
+    "Radiance": {
+      "resists": [
+        {
+          "damageSource": "Dark",
+          "multiplier": 0,
+          "resistType": "immune"
+        }
+      ]
+    },
+    "Heat Sink": {
+      "resists": [
+        {
+          "damageSource": "Fire",
+          "multiplier": 0,
+          "resistType": "immune",
+          "bonusEffect": "redirects, +Atk"
+        }
+      ]
+    },
+    "Gifted Mind": {
+      "resists": [
+        {
+          "damageSource": "Ghost",
+          "multiplier": 0,
+          "resistType": "immune"
+        },
+        {
+          "damageSource": "Bug",
+          "multiplier": 0,
+          "resistType": "immune"
+        },
+        {
+          "damageSource": "Dark",
+          "multiplier": 0,
+          "resistType": "immune"
+        }
+      ]
+    },
+    "Phantom": {
+      "addedType": "Ghost"
+    },
+    "Metallic": {
+      "addedType": "Steel"
+    },
+    "Half Drake": {
+      "addedType": "Dragon"
+    },
+    "Ice Age": {
+      "addedType": "Ice"
+    },
+    "Grounded": {
+      "addedType": "Ground"
+    },
+    "Aquatic": {
+      "addedType": "Water"
+    },
+    "Turboblaze": {
+      "addedType": "Fire"
+    },
+    "Teravolt": {
+      "addedType": "Electric"
+    },
+    "Fairy Tale": {
+      "addedType": "Fairy"
+    },
+    "Aquatic Dweller": {
+      "addedType": "Water"
+    },
+    "Metallic Jaws": {
+      "addedType": "Steel"
+    },
+    "Bruiser": {
+      "addedType": "Fighting"
+    },
+    "Rocky Exterior": {
+      "addedType": "Rock"
+    },
+    "Lightning Born": {
+      "addedType": "Electric"
+    },
+    "Komodo": {
+      "addedType": "Dragon"
+    },
+    "Lightsaber": {
+      "addedType": "Fire"
+    },
+    "Ominous Shroud": {
+      "addedType": "Ghost"
+    },
+    "Voltron": {
+      "addedType": "Steel"
+    },
+    "Waterborne": {
+      "addedType": "Water"
+    },
+    "Atlantic Ruler": {
+      "addedType": "Water"
+    },
+    "Draconic Might": {
+      "addedType": "Dragon"
+    },
+    "Dragonfruit": {
+      "addedType": "Dragon"
+    },
+    "Witch Broom": {
+      "addedType": "Psychic"
+    },
+    "Dune Terror": {
+      "conditionalResistances": [
+        {
+          "condition": {
+            "type": "weather",
+            "value": "Sand"
+          },
+          "resistance": [
+            {
+              "damageSource": "Physical",
+              "multiplier": 0.65,
+              "resistType": "resist"
+            },
+            {
+              "damageSource": "Special",
+              "multiplier": 0.65,
+              "resistType": "resist"
+            },
+            {
+              "damageSource": "Contact",
+              "multiplier": 0.65,
+              "resistType": "resist"
+            }
+          ]
+        }
+      ]
+    },
+    "Madness Enhancement": {
+      "conditionalResistances": [
+        {
+          "condition": {
+            "type": "weather",
+            "value": "Fog"
+          },
+          "resistance": [
+            {
+              "damageSource": "Physical",
+              "multiplier": 0.5,
+              "resistType": "resist"
+            },
+            {
+              "damageSource": "Special",
+              "multiplier": 0.5,
+              "resistType": "resist"
+            },
+            {
+              "damageSource": "Contact",
+              "multiplier": 0.5,
+              "resistType": "resist"
+            }
+          ]
+        }
+      ]
+    },
+    "Foggy Eye": {
+      "conditionalResistances": [
+        {
+          "condition": {
+            "type": "weather",
+            "value": "Fog"
+          },
+          "resistance": [
+            {
+              "damageSource": "Ghost",
+              "multiplier": 0.5,
+              "resistType": "resist"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/static/js/defensiveAbilities.js
+++ b/static/js/defensiveAbilities.js
@@ -4,8 +4,7 @@ export default {
       "resists": [
         {
           "damageSource": "Fire",
-          "multiplier": 0.5,
-          "resistType": "resist"
+          "multiplier": 0.5
         }
       ]
     },
@@ -13,8 +12,7 @@ export default {
       "resists": [
         {
           "damageSource": "Fire",
-          "multiplier": 0.5,
-          "resistType": "resist"
+          "multiplier": 0.5
         }
       ]
     },
@@ -22,13 +20,11 @@ export default {
       "resists": [
         {
           "damageSource": "Fire",
-          "multiplier": 0.5,
-          "resistType": "resist"
+          "multiplier": 0.5
         },
         {
           "damageSource": "Ice",
-          "multiplier": 0.5,
-          "resistType": "resist"
+          "multiplier": 0.5
         }
       ]
     },
@@ -36,8 +32,7 @@ export default {
       "resists": [
         {
           "damageSource": "Poison",
-          "multiplier": 0.5,
-          "resistType": "resist"
+          "multiplier": 0.5
         }
       ]
     },
@@ -45,8 +40,7 @@ export default {
       "resists": [
         {
           "damageSource": "Rock",
-          "multiplier": 0.5,
-          "resistType": "resist"
+          "multiplier": 0.5
         }
       ]
     },
@@ -54,8 +48,7 @@ export default {
       "resists": [
         {
           "damageSource": "Grass",
-          "multiplier": 0.5,
-          "resistType": "resist"
+          "multiplier": 0.5
         }
       ]
     },
@@ -64,7 +57,6 @@ export default {
         {
           "damageSource": "Water",
           "multiplier": 0.5,
-          "resistType": "resist",
           "bonusEffect": "+2 Def"
         }
       ]
@@ -73,8 +65,7 @@ export default {
       "resists": [
         {
           "damageSource": "Fire",
-          "multiplier": 0.5,
-          "resistType": "resist"
+          "multiplier": 0.5
         }
       ]
     },
@@ -82,8 +73,7 @@ export default {
       "resists": [
         {
           "damageSource": "Fire",
-          "multiplier": 0.5,
-          "resistType": "resist"
+          "multiplier": 0.5
         }
       ]
     },
@@ -91,8 +81,7 @@ export default {
       "resists": [
         {
           "damageSource": "Fire",
-          "multiplier": 0.5,
-          "resistType": "resist"
+          "multiplier": 0.5
         }
       ]
     },
@@ -100,8 +89,7 @@ export default {
       "resists": [
         {
           "damageSource": "Fire",
-          "multiplier": 0.5,
-          "resistType": "resist"
+          "multiplier": 0.5
         }
       ]
     },
@@ -109,13 +97,11 @@ export default {
       "resists": [
         {
           "damageSource": "Water",
-          "multiplier": 0.5,
-          "resistType": "resist"
+          "multiplier": 0.5
         },
         {
           "damageSource": "Ground",
-          "multiplier": 0.5,
-          "resistType": "resist"
+          "multiplier": 0.5
         }
       ]
     },
@@ -123,13 +109,11 @@ export default {
       "resists": [
         {
           "damageSource": "Fire",
-          "multiplier": 0.5,
-          "resistType": "resist"
+          "multiplier": 0.5
         },
         {
           "damageSource": "Ice",
-          "multiplier": 0.5,
-          "resistType": "resist"
+          "multiplier": 0.5
         }
       ]
     },
@@ -137,13 +121,11 @@ export default {
       "resists": [
         {
           "damageSource": "Fire",
-          "multiplier": 0.5,
-          "resistType": "resist"
+          "multiplier": 0.5
         },
         {
           "damageSource": "Ice",
-          "multiplier": 0.5,
-          "resistType": "resist"
+          "multiplier": 0.5
         }
       ]
     },
@@ -151,8 +133,7 @@ export default {
       "resists": [
         {
           "damageSource": "Ghost",
-          "multiplier": 0.5,
-          "resistType": "resist"
+          "multiplier": 0.5
         }
       ]
     },
@@ -160,13 +141,11 @@ export default {
       "resists": [
         {
           "damageSource": "Ghost",
-          "multiplier": 0.5,
-          "resistType": "resist"
+          "multiplier": 0.5
         },
         {
           "damageSource": "Dark",
-          "multiplier": 0.5,
-          "resistType": "resist"
+          "multiplier": 0.5
         }
       ]
     },
@@ -174,18 +153,15 @@ export default {
       "resists": [
         {
           "damageSource": "Dark",
-          "multiplier": 0.5,
-          "resistType": "resist"
+          "multiplier": 0.5
         },
         {
           "damageSource": "Ghost",
-          "multiplier": 0.5,
-          "resistType": "resist"
+          "multiplier": 0.5
         },
         {
           "damageSource": "Psychic",
-          "multiplier": 0.5,
-          "resistType": "resist"
+          "multiplier": 0.5
         }
       ]
     },
@@ -193,18 +169,15 @@ export default {
       "resists": [
         {
           "damageSource": "Fire",
-          "multiplier": 0.5,
-          "resistType": "resist"
+          "multiplier": 0.5
         },
         {
           "damageSource": "Electric",
-          "multiplier": 0.5,
-          "resistType": "resist"
+          "multiplier": 0.5
         },
         {
           "damageSource": "Water",
-          "multiplier": 0.5,
-          "resistType": "resist"
+          "multiplier": 0.5
         }
       ]
     },
@@ -212,13 +185,11 @@ export default {
       "resists": [
         {
           "damageSource": "Water",
-          "multiplier": 0.5,
-          "resistType": "resist"
+          "multiplier": 0.5
         },
         {
           "damageSource": "Ice",
-          "multiplier": 0.5,
-          "resistType": "resist"
+          "multiplier": 0.5
         }
       ]
     },
@@ -226,8 +197,7 @@ export default {
       "resists": [
         {
           "damageSource": "Poison",
-          "multiplier": 0.5,
-          "resistType": "resist"
+          "multiplier": 0.5
         }
       ]
     },
@@ -235,13 +205,11 @@ export default {
       "resists": [
         {
           "damageSource": "Fire",
-          "multiplier": 0.25,
-          "resistType": "resist"
+          "multiplier": 0.25
         },
         {
           "damageSource": "Ice",
-          "multiplier": 0.25,
-          "resistType": "resist"
+          "multiplier": 0.25
         }
       ]
     },
@@ -250,13 +218,11 @@ export default {
         {
           "damageSource": "Water",
           "multiplier": 0,
-          "resistType": "immune",
           "bonusEffect": "heals from Water"
         },
         {
           "damageSource": "Fire",
-          "multiplier": 2,
-          "resistType": "weakness"
+          "multiplier": 2
         }
       ]
     },
@@ -264,23 +230,19 @@ export default {
       "resists": [
         {
           "damageSource": "Fire",
-          "multiplier": 0.5,
-          "resistType": "resist"
+          "multiplier": 0.5
         },
         {
           "damageSource": "Physical",
-          "multiplier": 0.8,
-          "resistType": "resist"
+          "multiplier": 0.8
         },
         {
           "damageSource": "Special",
-          "multiplier": 0.8,
-          "resistType": "resist"
+          "multiplier": 0.8
         },
         {
           "damageSource": "Contact",
-          "multiplier": 0.8,
-          "resistType": "resist"
+          "multiplier": 0.8
         }
       ]
     },
@@ -288,23 +250,19 @@ export default {
       "resists": [
         {
           "damageSource": "Fire",
-          "multiplier": 0.5,
-          "resistType": "resist"
+          "multiplier": 0.5
         },
         {
           "damageSource": "Physical",
-          "multiplier": 0.8,
-          "resistType": "resist"
+          "multiplier": 0.8
         },
         {
           "damageSource": "Special",
-          "multiplier": 0.8,
-          "resistType": "resist"
+          "multiplier": 0.8
         },
         {
           "damageSource": "Contact",
-          "multiplier": 0.8,
-          "resistType": "resist"
+          "multiplier": 0.8
         }
       ]
     },
@@ -312,13 +270,11 @@ export default {
       "resists": [
         {
           "damageSource": "Fire",
-          "multiplier": 2,
-          "resistType": "weakness"
+          "multiplier": 2
         },
         {
           "damageSource": "Contact",
-          "multiplier": 0.5,
-          "resistType": "resist"
+          "multiplier": 0.5
         }
       ]
     },
@@ -326,13 +282,11 @@ export default {
       "resists": [
         {
           "damageSource": "Fire",
-          "multiplier": 2,
-          "resistType": "weakness"
+          "multiplier": 2
         },
         {
           "damageSource": "Contact",
-          "multiplier": 0.5,
-          "resistType": "resist"
+          "multiplier": 0.5
         }
       ]
     },
@@ -340,13 +294,11 @@ export default {
       "resists": [
         {
           "damageSource": "Water",
-          "multiplier": 2,
-          "resistType": "weakness"
+          "multiplier": 2
         },
         {
           "damageSource": "Contact",
-          "multiplier": 0.5,
-          "resistType": "resist"
+          "multiplier": 0.5
         }
       ]
     },
@@ -354,13 +306,11 @@ export default {
       "resists": [
         {
           "damageSource": "Fire",
-          "multiplier": 2,
-          "resistType": "weakness"
+          "multiplier": 2
         },
         {
           "damageSource": "Contact",
-          "multiplier": 0.5,
-          "resistType": "resist"
+          "multiplier": 0.5
         }
       ]
     },
@@ -368,13 +318,11 @@ export default {
       "resists": [
         {
           "damageSource": "Fire",
-          "multiplier": 4,
-          "resistType": "weakness"
+          "multiplier": 4
         },
         {
           "damageSource": "Contact",
-          "multiplier": 0.25,
-          "resistType": "resist"
+          "multiplier": 0.25
         }
       ]
     },
@@ -382,8 +330,7 @@ export default {
       "resists": [
         {
           "damageSource": "Physical",
-          "multiplier": 0.5,
-          "resistType": "resist"
+          "multiplier": 0.5
         }
       ]
     },
@@ -391,8 +338,7 @@ export default {
       "resists": [
         {
           "damageSource": "Physical",
-          "multiplier": 0.5,
-          "resistType": "resist"
+          "multiplier": 0.5
         }
       ]
     },
@@ -400,13 +346,11 @@ export default {
       "resists": [
         {
           "damageSource": "Physical",
-          "multiplier": 0.5,
-          "resistType": "resist"
+          "multiplier": 0.5
         },
         {
           "damageSource": "Special",
-          "multiplier": 0.5,
-          "resistType": "resist"
+          "multiplier": 0.5
         }
       ]
     },
@@ -414,8 +358,7 @@ export default {
       "resists": [
         {
           "damageSource": "Special",
-          "multiplier": 0.5,
-          "resistType": "resist"
+          "multiplier": 0.5
         }
       ]
     },
@@ -423,8 +366,7 @@ export default {
       "resists": [
         {
           "damageSource": "Special",
-          "multiplier": 0.5,
-          "resistType": "resist"
+          "multiplier": 0.5
         }
       ]
     },
@@ -432,8 +374,7 @@ export default {
       "resists": [
         {
           "damageSource": "Special",
-          "multiplier": 0.5,
-          "resistType": "resist"
+          "multiplier": 0.5
         }
       ]
     },
@@ -441,8 +382,7 @@ export default {
       "resists": [
         {
           "damageSource": "Special",
-          "multiplier": 0.5,
-          "resistType": "resist"
+          "multiplier": 0.5
         }
       ]
     },
@@ -450,8 +390,7 @@ export default {
       "resists": [
         {
           "damageSource": "Special",
-          "multiplier": 0.7,
-          "resistType": "resist"
+          "multiplier": 0.7
         }
       ]
     },
@@ -459,18 +398,15 @@ export default {
       "resists": [
         {
           "damageSource": "Physical",
-          "multiplier": 0.85,
-          "resistType": "resist"
+          "multiplier": 0.85
         },
         {
           "damageSource": "Special",
-          "multiplier": 0.85,
-          "resistType": "resist"
+          "multiplier": 0.85
         },
         {
           "damageSource": "Contact",
-          "multiplier": 0.85,
-          "resistType": "resist"
+          "multiplier": 0.85
         }
       ],
       "addedType": "Ghost"
@@ -479,18 +415,15 @@ export default {
       "resists": [
         {
           "damageSource": "Physical",
-          "multiplier": 0.9,
-          "resistType": "resist"
+          "multiplier": 0.9
         },
         {
           "damageSource": "Special",
-          "multiplier": 0.9,
-          "resistType": "resist"
+          "multiplier": 0.9
         },
         {
           "damageSource": "Contact",
-          "multiplier": 0.9,
-          "resistType": "resist"
+          "multiplier": 0.9
         }
       ],
       "addedType": "Rock"
@@ -499,18 +432,15 @@ export default {
       "resists": [
         {
           "damageSource": "Physical",
-          "multiplier": 0.8,
-          "resistType": "resist"
+          "multiplier": 0.8
         },
         {
           "damageSource": "Special",
-          "multiplier": 0.8,
-          "resistType": "resist"
+          "multiplier": 0.8
         },
         {
           "damageSource": "Contact",
-          "multiplier": 0.8,
-          "resistType": "resist"
+          "multiplier": 0.8
         }
       ]
     },
@@ -518,18 +448,15 @@ export default {
       "resists": [
         {
           "damageSource": "Physical",
-          "multiplier": 0.8,
-          "resistType": "resist"
+          "multiplier": 0.8
         },
         {
           "damageSource": "Special",
-          "multiplier": 0.8,
-          "resistType": "resist"
+          "multiplier": 0.8
         },
         {
           "damageSource": "Contact",
-          "multiplier": 0.8,
-          "resistType": "resist"
+          "multiplier": 0.8
         }
       ]
     },
@@ -537,18 +464,15 @@ export default {
       "resists": [
         {
           "damageSource": "Physical",
-          "multiplier": 0.8,
-          "resistType": "resist"
+          "multiplier": 0.8
         },
         {
           "damageSource": "Special",
-          "multiplier": 0.8,
-          "resistType": "resist"
+          "multiplier": 0.8
         },
         {
           "damageSource": "Contact",
-          "multiplier": 0.8,
-          "resistType": "resist"
+          "multiplier": 0.8
         }
       ]
     },
@@ -556,18 +480,15 @@ export default {
       "resists": [
         {
           "damageSource": "Physical",
-          "multiplier": 0.8,
-          "resistType": "resist"
+          "multiplier": 0.8
         },
         {
           "damageSource": "Special",
-          "multiplier": 0.8,
-          "resistType": "resist"
+          "multiplier": 0.8
         },
         {
           "damageSource": "Contact",
-          "multiplier": 0.8,
-          "resistType": "resist"
+          "multiplier": 0.8
         }
       ]
     },
@@ -575,18 +496,15 @@ export default {
       "resists": [
         {
           "damageSource": "Physical",
-          "multiplier": 0.8,
-          "resistType": "resist"
+          "multiplier": 0.8
         },
         {
           "damageSource": "Special",
-          "multiplier": 0.8,
-          "resistType": "resist"
+          "multiplier": 0.8
         },
         {
           "damageSource": "Contact",
-          "multiplier": 0.8,
-          "resistType": "resist"
+          "multiplier": 0.8
         }
       ]
     },
@@ -594,18 +512,15 @@ export default {
       "resists": [
         {
           "damageSource": "Physical",
-          "multiplier": 0.8,
-          "resistType": "resist"
+          "multiplier": 0.8
         },
         {
           "damageSource": "Special",
-          "multiplier": 0.8,
-          "resistType": "resist"
+          "multiplier": 0.8
         },
         {
           "damageSource": "Contact",
-          "multiplier": 0.8,
-          "resistType": "resist"
+          "multiplier": 0.8
         }
       ]
     },
@@ -613,18 +528,15 @@ export default {
       "resists": [
         {
           "damageSource": "Physical",
-          "multiplier": 0.9,
-          "resistType": "resist"
+          "multiplier": 0.9
         },
         {
           "damageSource": "Special",
-          "multiplier": 0.9,
-          "resistType": "resist"
+          "multiplier": 0.9
         },
         {
           "damageSource": "Contact",
-          "multiplier": 0.9,
-          "resistType": "resist"
+          "multiplier": 0.9
         }
       ]
     },
@@ -632,18 +544,15 @@ export default {
       "resists": [
         {
           "damageSource": "Physical",
-          "multiplier": 0.7,
-          "resistType": "resist"
+          "multiplier": 0.7
         },
         {
           "damageSource": "Special",
-          "multiplier": 0.7,
-          "resistType": "resist"
+          "multiplier": 0.7
         },
         {
           "damageSource": "Contact",
-          "multiplier": 0.7,
-          "resistType": "resist"
+          "multiplier": 0.7
         }
       ]
     },
@@ -651,18 +560,15 @@ export default {
       "resists": [
         {
           "damageSource": "Physical",
-          "multiplier": 0.8,
-          "resistType": "resist"
+          "multiplier": 0.8
         },
         {
           "damageSource": "Special",
-          "multiplier": 0.8,
-          "resistType": "resist"
+          "multiplier": 0.8
         },
         {
           "damageSource": "Contact",
-          "multiplier": 0.8,
-          "resistType": "resist"
+          "multiplier": 0.8
         }
       ]
     },
@@ -670,18 +576,15 @@ export default {
       "resists": [
         {
           "damageSource": "Physical",
-          "multiplier": 0.8,
-          "resistType": "resist"
+          "multiplier": 0.8
         },
         {
           "damageSource": "Special",
-          "multiplier": 0.8,
-          "resistType": "resist"
+          "multiplier": 0.8
         },
         {
           "damageSource": "Contact",
-          "multiplier": 0.8,
-          "resistType": "resist"
+          "multiplier": 0.8
         }
       ]
     },
@@ -689,18 +592,15 @@ export default {
       "resists": [
         {
           "damageSource": "Physical",
-          "multiplier": 0.8,
-          "resistType": "resist"
+          "multiplier": 0.8
         },
         {
           "damageSource": "Special",
-          "multiplier": 0.8,
-          "resistType": "resist"
+          "multiplier": 0.8
         },
         {
           "damageSource": "Contact",
-          "multiplier": 0.8,
-          "resistType": "resist"
+          "multiplier": 0.8
         }
       ]
     },
@@ -708,23 +608,19 @@ export default {
       "resists": [
         {
           "damageSource": "SE",
-          "multiplier": 0.65,
-          "resistType": "resist"
+          "multiplier": 0.65
         },
         {
           "damageSource": "Physical",
-          "multiplier": 0.8,
-          "resistType": "resist"
+          "multiplier": 0.8
         },
         {
           "damageSource": "Special",
-          "multiplier": 0.8,
-          "resistType": "resist"
+          "multiplier": 0.8
         },
         {
           "damageSource": "Contact",
-          "multiplier": 0.8,
-          "resistType": "resist"
+          "multiplier": 0.8
         }
       ]
     },
@@ -732,8 +628,7 @@ export default {
       "resists": [
         {
           "damageSource": "SE",
-          "multiplier": 0.65,
-          "resistType": "resist"
+          "multiplier": 0.65
         }
       ]
     },
@@ -741,8 +636,7 @@ export default {
       "resists": [
         {
           "damageSource": "SE",
-          "multiplier": 0.65,
-          "resistType": "resist"
+          "multiplier": 0.65
         }
       ]
     },
@@ -750,8 +644,7 @@ export default {
       "resists": [
         {
           "damageSource": "SE",
-          "multiplier": 0.65,
-          "resistType": "resist"
+          "multiplier": 0.65
         }
       ]
     },
@@ -759,8 +652,7 @@ export default {
       "resists": [
         {
           "damageSource": "SE",
-          "multiplier": 0.65,
-          "resistType": "resist"
+          "multiplier": 0.65
         }
       ]
     },
@@ -768,8 +660,7 @@ export default {
       "resists": [
         {
           "damageSource": "SE",
-          "multiplier": 0.65,
-          "resistType": "resist"
+          "multiplier": 0.65
         }
       ]
     },
@@ -777,8 +668,7 @@ export default {
       "resists": [
         {
           "damageSource": "SE",
-          "multiplier": 0.65,
-          "resistType": "resist"
+          "multiplier": 0.65
         }
       ]
     },
@@ -786,8 +676,7 @@ export default {
       "resists": [
         {
           "damageSource": "SE",
-          "multiplier": 0.5,
-          "resistType": "resist"
+          "multiplier": 0.5
         }
       ]
     },
@@ -795,8 +684,7 @@ export default {
       "resists": [
         {
           "damageSource": "SE",
-          "multiplier": 0.65,
-          "resistType": "resist"
+          "multiplier": 0.65
         }
       ]
     },
@@ -810,13 +698,11 @@ export default {
           "resistance": [
             {
               "damageSource": "Ghost",
-              "multiplier": 0.5,
-              "resistType": "resist"
+              "multiplier": 0.5
             },
             {
               "damageSource": "Dark",
-              "multiplier": 0.5,
-              "resistType": "resist"
+              "multiplier": 0.5
             }
           ]
         }
@@ -832,8 +718,7 @@ export default {
           "resistance": [
             {
               "damageSource": "Fire",
-              "multiplier": 0.5,
-              "resistType": "resist"
+              "multiplier": 0.5
             }
           ]
         }
@@ -849,8 +734,7 @@ export default {
           "resistance": [
             {
               "damageSource": "Special",
-              "multiplier": 0.5,
-              "resistType": "resist"
+              "multiplier": 0.5
             }
           ]
         }
@@ -866,8 +750,7 @@ export default {
           "resistance": [
             {
               "damageSource": "Physical",
-              "multiplier": 0.5,
-              "resistType": "resist"
+              "multiplier": 0.5
             }
           ]
         }
@@ -883,18 +766,15 @@ export default {
           "resistance": [
             {
               "damageSource": "Physical",
-              "multiplier": 0.5,
-              "resistType": "resist"
+              "multiplier": 0.5
             },
             {
               "damageSource": "Special",
-              "multiplier": 0.5,
-              "resistType": "resist"
+              "multiplier": 0.5
             },
             {
               "damageSource": "Contact",
-              "multiplier": 0.5,
-              "resistType": "resist"
+              "multiplier": 0.5
             }
           ]
         }
@@ -905,7 +785,6 @@ export default {
         {
           "damageSource": "Fire",
           "multiplier": 0,
-          "resistType": "immune",
           "bonusEffect": "x1.5 Fire moves after hit"
         }
       ]
@@ -915,7 +794,6 @@ export default {
         {
           "damageSource": "Grass",
           "multiplier": 0,
-          "resistType": "immune",
           "bonusEffect": "redirects, +Atk"
         }
       ]
@@ -925,7 +803,6 @@ export default {
         {
           "damageSource": "Electric",
           "multiplier": 0,
-          "resistType": "immune",
           "bonusEffect": "heals 25% HP"
         }
       ]
@@ -935,7 +812,6 @@ export default {
         {
           "damageSource": "Electric",
           "multiplier": 0,
-          "resistType": "immune",
           "bonusEffect": "redirects, +Atk"
         }
       ]
@@ -945,7 +821,6 @@ export default {
         {
           "damageSource": "Electric",
           "multiplier": 0,
-          "resistType": "immune",
           "bonusEffect": "+Speed"
         }
       ]
@@ -955,7 +830,6 @@ export default {
         {
           "damageSource": "Water",
           "multiplier": 0,
-          "resistType": "immune",
           "bonusEffect": "heals 25% HP"
         }
       ]
@@ -965,7 +839,6 @@ export default {
         {
           "damageSource": "Water",
           "multiplier": 0,
-          "resistType": "immune",
           "bonusEffect": "redirects, +Atk"
         }
       ]
@@ -975,7 +848,6 @@ export default {
         {
           "damageSource": "Water",
           "multiplier": 0,
-          "resistType": "immune",
           "bonusEffect": "sets Mist"
         }
       ]
@@ -984,8 +856,7 @@ export default {
       "resists": [
         {
           "damageSource": "Ground",
-          "multiplier": 0,
-          "resistType": "immune"
+          "multiplier": 0
         }
       ]
     },
@@ -993,8 +864,7 @@ export default {
       "resists": [
         {
           "damageSource": "Ground",
-          "multiplier": 0,
-          "resistType": "immune"
+          "multiplier": 0
         }
       ],
       "addedType": "Dragon"
@@ -1003,8 +873,7 @@ export default {
       "resists": [
         {
           "damageSource": "Rock",
-          "multiplier": 0,
-          "resistType": "immune"
+          "multiplier": 0
         }
       ]
     },
@@ -1013,7 +882,6 @@ export default {
         {
           "damageSource": "Poison",
           "multiplier": 0,
-          "resistType": "immune",
           "bonusEffect": "redirects, heals 25% HP"
         }
       ]
@@ -1023,7 +891,6 @@ export default {
         {
           "damageSource": "Flying",
           "multiplier": 0,
-          "resistType": "immune",
           "bonusEffect": "+Speed"
         }
       ]
@@ -1033,7 +900,6 @@ export default {
         {
           "damageSource": "Fire",
           "multiplier": 0,
-          "resistType": "immune",
           "bonusEffect": "+Def sharply"
         }
       ]
@@ -1043,13 +909,11 @@ export default {
         {
           "damageSource": "Fire",
           "multiplier": 0,
-          "resistType": "immune",
           "bonusEffect": "Fire: x1.5 Fire moves | Water: heals 25% HP"
         },
         {
           "damageSource": "Water",
-          "multiplier": 0,
-          "resistType": "immune"
+          "multiplier": 0
         }
       ]
     },
@@ -1058,7 +922,6 @@ export default {
         {
           "damageSource": "Dark",
           "multiplier": 0,
-          "resistType": "immune",
           "bonusEffect": "+Atk"
         }
       ]
@@ -1068,7 +931,6 @@ export default {
         {
           "damageSource": "Ice",
           "multiplier": 0,
-          "resistType": "immune",
           "bonusEffect": "redirects, +Atk"
         }
       ]
@@ -1078,7 +940,6 @@ export default {
         {
           "damageSource": "Ground",
           "multiplier": 0,
-          "resistType": "immune",
           "bonusEffect": "heals 25% HP"
         }
       ]
@@ -1087,8 +948,7 @@ export default {
       "resists": [
         {
           "damageSource": "Ground",
-          "multiplier": 0,
-          "resistType": "immune"
+          "multiplier": 0
         }
       ],
       "addedType": "Psychic"
@@ -1097,8 +957,7 @@ export default {
       "resists": [
         {
           "damageSource": "Ground",
-          "multiplier": 0,
-          "resistType": "immune"
+          "multiplier": 0
         }
       ]
     },
@@ -1106,8 +965,7 @@ export default {
       "resists": [
         {
           "damageSource": "Ground",
-          "multiplier": 0,
-          "resistType": "immune"
+          "multiplier": 0
         }
       ]
     },
@@ -1116,7 +974,6 @@ export default {
         {
           "damageSource": "Ground",
           "multiplier": 0,
-          "resistType": "immune",
           "bonusEffect": "heals 25% HP"
         }
       ],
@@ -1129,8 +986,7 @@ export default {
           "resistance": [
             {
               "damageSource": "Water",
-              "multiplier": 0,
-              "resistType": "immune"
+              "multiplier": 0
             }
           ]
         }
@@ -1141,7 +997,6 @@ export default {
         {
           "damageSource": "Water",
           "multiplier": 0,
-          "resistType": "immune",
           "bonusEffect": "Water: heals 25% HP, redirects"
         }
       ]
@@ -1156,8 +1011,7 @@ export default {
           "resistance": [
             {
               "damageSource": "Water",
-              "multiplier": 0,
-              "resistType": "immune"
+              "multiplier": 0
             }
           ]
         }
@@ -1173,8 +1027,7 @@ export default {
           "resistance": [
             {
               "damageSource": "Fire",
-              "multiplier": 0,
-              "resistType": "immune"
+              "multiplier": 0
             }
           ]
         }
@@ -1184,8 +1037,7 @@ export default {
       "resists": [
         {
           "damageSource": "Ground",
-          "multiplier": 0,
-          "resistType": "immune"
+          "multiplier": 0
         }
       ],
       "addedType": "Fairy"
@@ -1194,8 +1046,7 @@ export default {
       "resists": [
         {
           "damageSource": "Dark",
-          "multiplier": 0,
-          "resistType": "immune"
+          "multiplier": 0
         }
       ]
     },
@@ -1204,7 +1055,6 @@ export default {
         {
           "damageSource": "Fire",
           "multiplier": 0,
-          "resistType": "immune",
           "bonusEffect": "redirects, +Atk"
         }
       ]
@@ -1213,18 +1063,15 @@ export default {
       "resists": [
         {
           "damageSource": "Ghost",
-          "multiplier": 0,
-          "resistType": "immune"
+          "multiplier": 0
         },
         {
           "damageSource": "Bug",
-          "multiplier": 0,
-          "resistType": "immune"
+          "multiplier": 0
         },
         {
           "damageSource": "Dark",
-          "multiplier": 0,
-          "resistType": "immune"
+          "multiplier": 0
         }
       ]
     },
@@ -1307,18 +1154,15 @@ export default {
           "resistance": [
             {
               "damageSource": "Physical",
-              "multiplier": 0.65,
-              "resistType": "resist"
+              "multiplier": 0.65
             },
             {
               "damageSource": "Special",
-              "multiplier": 0.65,
-              "resistType": "resist"
+              "multiplier": 0.65
             },
             {
               "damageSource": "Contact",
-              "multiplier": 0.65,
-              "resistType": "resist"
+              "multiplier": 0.65
             }
           ]
         }
@@ -1334,18 +1178,15 @@ export default {
           "resistance": [
             {
               "damageSource": "Physical",
-              "multiplier": 0.5,
-              "resistType": "resist"
+              "multiplier": 0.5
             },
             {
               "damageSource": "Special",
-              "multiplier": 0.5,
-              "resistType": "resist"
+              "multiplier": 0.5
             },
             {
               "damageSource": "Contact",
-              "multiplier": 0.5,
-              "resistType": "resist"
+              "multiplier": 0.5
             }
           ]
         }
@@ -1361,8 +1202,7 @@ export default {
           "resistance": [
             {
               "damageSource": "Ghost",
-              "multiplier": 0.5,
-              "resistType": "resist"
+              "multiplier": 0.5
             }
           ]
         }

--- a/static/js/hydrate/hydrate.js
+++ b/static/js/hydrate/hydrate.js
@@ -13,6 +13,7 @@ import { hydrateSpecies } from "./species.js"
 import { hydrateLocation } from "./locations.js"
 import { addAllOtherEveeMoves } from "./moves.js"
 import { takeMovesFromPreEvolution } from "./moves.js"
+import { populateTypeCalc } from "../panels/typecalc_panel.js"
 
 export const nodeLists = {
     species: [],
@@ -22,7 +23,7 @@ export const nodeLists = {
     trainers: [],
 }
 
-export function hydrate(firstLoad=false) {
+export function hydrate(firstLoad = false) {
     if (!gameData) {
         return console.warn("couldn't find gameData")
     }
@@ -63,22 +64,23 @@ export function hydrate(firstLoad=false) {
         [takeMovesFromPreEvolution, "take moves from evo"],
         [addAllOtherEveeMoves, "adding ER eevees moves"],
         [initFormatShowdown, "showdown data"],
+        [populateTypeCalc, "type calculator"],
     ]
     const stepLen = steps.length
-    for (let i = 0; i < stepLen; i++){
+    for (let i = 0; i < stepLen; i++) {
         const step = steps[i]
-        if (firstLoad){
+        if (firstLoad) {
             load(step[0], step[1], i == stepLen - 1)
         } else {
             step[0]()
         }
-    } 
+    }
 }
 
 export let itemList = []
-function setLists(){
+function setLists() {
     itemList = gameData.items.map(x => x.name)
-    
+
 }
 
 

--- a/static/js/panels/typecalc_panel.js
+++ b/static/js/panels/typecalc_panel.js
@@ -1,0 +1,476 @@
+import { gameData } from "../data_version.js";
+import { e } from "../utils.js";
+import { getTypeEffectiveness } from "../weakness.js";
+
+// All defensive abilities grouped by effect type
+const defensiveAbilities = {
+    // Immunity: nullify damage from type entirely
+    immunity: {
+        "Flash Fire": ["Fire"],
+        "Sap Sipper": ["Grass"],
+        "Volt Absorb": ["Electric"],
+        "Lightning Rod": ["Electric"],
+        "Motor Drive": ["Electric"],
+        "Water Absorb": ["Water"],
+        "Dry Skin": ["Water"],
+        "Storm Drain": ["Water"],
+        "Evaporate": ["Water"],
+        "Levitate": ["Ground"],
+        "Dragonfly": ["Ground"],
+        "Mountaineer": ["Rock"],
+        "Poison Absorb": ["Poison"],
+        "Aerodynamics": ["Flying"],
+        "Well Baked Body": ["Fire"],
+        "Elemental Vortex": ["Fire", "Water"],
+        "Justified": ["Dark"],
+        "Ice Dew": ["Ice"],
+        "Earth Eater": ["Ground"],
+        "Hover": ["Ground"],
+        "Aerialist": ["Ground"],
+        "Imposing Wings": ["Ground"],
+        "Desolate Sun": ["Ground", "Water"],
+        "Reservoir": ["Water"],
+        "Desolate Land": ["Water"],
+        "Primordial Sea": ["Fire"],
+        "Fey Flight": ["Ground"],
+        "Radiance": ["Dark"],
+        "Heat Sink": ["Fire"],
+    },
+    // Adds a defensive type
+    addType: {
+        "Phantom": "Ghost",
+        "Metallic": "Steel",
+        "Dragonfly": "Dragon",
+        "Half Drake": "Dragon",
+        "Ice Age": "Ice",
+        "Grounded": "Ground",
+        "Aquatic": "Water",
+        "Turboblaze": "Fire",
+        "Teravolt": "Electric",
+        "Fairy Tale": "Fairy",
+        "Aquatic Dweller": "Water",
+        "Metallic Jaws": "Steel",
+        "Bruiser": "Fighting",
+        "Rocky Exterior": "Rock",
+        "Lightning Born": "Electric",
+        "Komodo": "Dragon",
+        "Fey Flight": "Fairy",
+        "Dead Bark": "Ghost",
+        "Lightsaber": "Fire",
+        "Hover": "Psychic",
+        "Ominous Shroud": "Ghost",
+        "Voltron": "Steel",
+        "Waterborne": "Water",
+        "Atlantic Ruler": "Water",
+        "Draconic Might": "Dragon",
+        "Dragonfruit": "Dragon",
+        "Witch Broom": "Psychic",
+        "Rock Armor": "Rock",
+    },
+    // Type-based multipliers: { ability: { type: multiplier } }
+    typeMultipliers: {
+        // x0.5 resists
+        "Water Bubble": { "Fire": 0.5 },
+        "Seaweed": { "Fire (if Grass-type)": 0.5 },
+        "Heatproof": { "Fire": 0.5 },
+        "Iron Giant": { "Fire": 0.5 },
+        "Thick Fat": { "Fire": 0.5, "Ice": 0.5 },
+        "Immunity": { "Poison": 0.5 },
+        "Fossilized": { "Rock": 0.5 },
+        "Raw Wood": { "Grass": 0.5 },
+        "Water Compaction": { "Water": 0.5 },
+        "Old Mariner": { "Fire": 0.5 },
+        "Flame Bubble": { "Fire": 0.5 },
+        "Deep Freeze": { "Fire": 0.5 },
+        "Droideka": { "Fire": 0.5 },
+        "Thermal Entropy": { "Fire": 0.5 },
+        "Strong Foundation": { "Water": 0.5, "Ground": 0.5 },
+        "Sumo Guard": { "Fire": 0.5, "Ice": 0.5 },
+        "Tummyache": { "Fire": 0.5, "Ice": 0.5 },
+        "Purifying Salt": { "Ghost": 0.5 },
+        "Heavy Metal": { "Ghost": 0.5, "Dark": 0.5 },
+        "Aegis Ward": { "Dark": 0.5, "Ghost": 0.5, "Psychic": 0.5 },
+        "Elemental Aegis": { "Fire": 0.5, "Electric": 0.5, "Water": 0.5 },
+        "Magma Armor": { "Water": 0.5, "Ice": 0.5 },
+        "Hyper Cleanse": { "Poison": 0.5 },
+        // x0.25 quad resists
+        "Thick Blubber": { "Fire": 0.25, "Ice": 0.25 },
+        // x2 weaknesses
+        "Fluffy": { "Fire": 2 },
+        "Puffy": { "Fire": 2 },
+        "Liquified": { "Water": 2 },
+        "Dry Skin": { "Fire": 2 },
+        "Massive Pelt": { "Fire": 2 },
+        // x4 weaknesses
+        "Fluffiest": { "Fire": 4 },
+    },
+    // Damage category modifiers: { ability: { Physical, Special, Contact } multiplier }
+    dmgCategory: {
+        "Fur Coat": { Physical: 0.5 },
+        "Apple Enlightenment": { Physical: 0.5 },
+        "Prismatic Fur": { Physical: 0.5, Special: 0.5 },
+        "Ice Scales": { Special: 0.5 },
+        "Fire Scales": { Special: 0.5 },
+        "Rainbow Scales": { Special: 0.5 },
+        "Fluffy": { Contact: 0.5 },
+        "Puffy": { Contact: 0.5 },
+        "Massive Pelt": { Contact: 0.5 },
+        "Liquified": { Contact: 0.5 },
+        "Fluffiest": { Contact: 0.25 },
+        "Ice Plumes": { Special: 0.5 },
+        "Prism Scales": { Special: 0.7 },
+        "Sand Guard": { "Special (in sand)": 0.5 },
+        "Sun Basking": { "Physical (in sun)": 0.5 },
+        // General damage reduction (all categories)
+        "Dead Bark": { Physical: 0.85, Special: 0.85, Contact: 0.85 },
+        "Rock Armor": { Physical: 0.9, Special: 0.9, Contact: 0.9 },
+        "Battle Armor": { Physical: 0.8, Special: 0.8, Contact: 0.8 },
+        "Shell Armor": { Physical: 0.8, Special: 0.8, Contact: 0.8 },
+        "Dream State": { Physical: 0.8, Special: 0.8, Contact: 0.8 },
+        "Crust Coat": { Physical: 0.8, Special: 0.8, Contact: 0.8 },
+        "Parry": { Physical: 0.8, Special: 0.8, Contact: 0.8 },
+        "Deflect": { Physical: 0.8, Special: 0.8, Contact: 0.8 },
+        "Feathercoat": { Physical: 0.9, Special: 0.9, Contact: 0.9 },
+        "Mucus Membrane": { Physical: 0.7, Special: 0.7, Contact: 0.7 },
+        // Combos inheriting Shell Armor / Battle Armor (20% less)
+        "Faraday Cage": { Physical: 0.8, Special: 0.8, Contact: 0.8 },
+        "Toxic Shell": { Physical: 0.8, Special: 0.8, Contact: 0.8 },
+        "Shattered Armor": { Physical: 0.8, Special: 0.8, Contact: 0.8 },
+        "Fortress": { Physical: 0.8, Special: 0.8, Contact: 0.8 },
+    },
+    // Stat boost when hit by type (informational only)
+    statBoost: {
+        "Cryo Architect": ["Water", "Ice"],
+    },
+    // Nullifies weakness to types (informational only)
+    nullWeakness: {
+        "Gifted Mind": ["Ghost", "Bug", "Dark"],
+    },
+    // Reduces super-effective damage (informational — affects all SE types)
+    resistSE: {
+        "Filter": 0.65,
+        "Solid Rock": 0.65,
+        "Prism Armor": 0.65,
+        "Permafrost": 0.65,
+        "Thick Skin": 0.65,
+        "Flame Shield": 0.65,
+        "Primal Armor": 0.5,
+        "Refrigerator": 0.65,
+        "Fortress": 0.65,
+    },
+};
+
+// Build sorted list of all defensive ability names
+function getAllDefensiveAbilityNames() {
+    const names = new Set();
+    for (const category of Object.values(defensiveAbilities)) {
+        for (const name of Object.keys(category)) names.add(name);
+    }
+    return [...names].sort();
+}
+
+const defensiveAbilityNames = getAllDefensiveAbilityNames();
+
+// Helper: collect values from a map category for selected abilities
+function collectFromMap(category, abilities, collector) {
+    for (const abi of abilities) {
+        const val = category[abi];
+        if (val) collector(val, abi);
+    }
+}
+
+// Helper: get usable types (filter out None, Stellar, Mystery)
+function getUsableTypes() {
+    return gameData.typeT.filter(
+        (t) => t !== "None" && t !== "Stellar" && t !== "Mystery",
+    );
+}
+
+// --- Dropdown ---
+
+const dropdownStates = {};
+
+function closeAllDropdowns() {
+    $(".tc-dropdown-list").hide();
+    for (const id in dropdownStates) dropdownStates[id].isOpen = false;
+}
+
+function setupDropdown(btnId, options) {
+    const btn = $(`#${btnId}`);
+    const list = btn.next(".tc-dropdown-list");
+    dropdownStates[btnId] = { isOpen: false };
+
+    function buildList(filter) {
+        const frag = document.createDocumentFragment();
+        const query = (filter || "").toLowerCase();
+        const currentValue = btn[0].dataset.value;
+        for (const opt of options) {
+            if (query && opt.value && !opt.label.toLowerCase().includes(query)) continue;
+            const div = document.createElement("div");
+            div.textContent = opt.label;
+            div.dataset.value = opt.value;
+            if (opt.value && opt.value === currentValue) div.className = "tc-dropdown-selected";
+            div.onmousedown = (ev) => {
+                ev.preventDefault();
+                selectOption(opt);
+            };
+            frag.append(div);
+        }
+        list.empty();
+        list[0].appendChild(frag);
+    }
+
+    function selectOption(opt) {
+        btn.val(opt.label);
+        btn[0].dataset.value = opt.value;
+        close();
+        btn[0].blur();
+        updateReadonly();
+        recalculate();
+    }
+
+    function open(filter) {
+        closeAllDropdowns();
+        buildList(filter);
+        list.show();
+        dropdownStates[btnId].isOpen = true;
+    }
+
+    function close() {
+        list.hide();
+        dropdownStates[btnId].isOpen = false;
+    }
+
+    function updateReadonly() {
+        btn[0].readOnly = !btn[0].dataset.value;
+    }
+
+    buildList();
+    updateReadonly();
+
+    btn.off("focus").on("focus", () => {
+        if (btn[0].readOnly) return;
+        btn.val("");
+        open("");
+    });
+
+    btn.off("input").on("input", () => open(btn.val()));
+
+    btn.off("blur").on("blur", () => {
+        close();
+        const match = options.find((o) => o.value === btn[0].dataset.value);
+        btn.val(match ? match.label : "-- None --");
+    });
+
+    btn.off("mousedown").on("mousedown", (ev) => {
+        if (dropdownStates[btnId].isOpen) {
+            ev.preventDefault();
+            close();
+            btn[0].blur();
+            return;
+        }
+        if (btn[0].readOnly) {
+            ev.preventDefault();
+            btn[0].readOnly = false;
+            btn.val("");
+            btn[0].focus();
+            open("");
+        }
+    });
+}
+
+// --- Init ---
+
+export function populateTypeCalc() {
+    const types = getUsableTypes();
+    const typeOptions = types.map((t) => ({ label: t, value: t }));
+    const noneOption = { label: "-- None --", value: "" };
+
+    setupDropdown("typecalc-type1", typeOptions);
+    $("#typecalc-type1").val(types[0]);
+    $("#typecalc-type1")[0].dataset.value = types[0];
+
+    setupDropdown("typecalc-type2", [noneOption, ...typeOptions]);
+    $("#typecalc-type2")[0].dataset.value = "";
+
+    const abiOptions = [noneOption, ...defensiveAbilityNames.map((n) => ({ label: n, value: n }))];
+    for (let i = 0; i < 4; i++) {
+        setupDropdown(`typecalc-abi${i}`, abiOptions);
+        $(`#typecalc-abi${i}`)[0].dataset.value = "";
+    }
+
+    $(document).off("click.typecalc").on("click.typecalc", (ev) => {
+        if (!$(ev.target).closest(".tc-dropdown-wrap").length) closeAllDropdowns();
+    });
+
+    recalculate();
+}
+
+// --- Calculation ---
+
+function getSelectedAbilities() {
+    const seen = new Set();
+    const result = [];
+    for (let i = 0; i < 4; i++) {
+        const val = $(`#typecalc-abi${i}`)[0].dataset.value;
+        if (val && !seen.has(val)) {
+            seen.add(val);
+            result.push(val);
+        }
+    }
+    return result;
+}
+
+function recalculate() {
+    const type1 = $("#typecalc-type1")[0].dataset.value;
+    if (!type1) {
+        $("#typecalc-result").empty();
+        return;
+    }
+    const type2 = $("#typecalc-type2")[0].dataset.value || "";
+    const defTypes = [type1];
+    if (type2 && type2 !== type1) defTypes.push(type2);
+
+    const abilities = getSelectedAbilities();
+
+    // Collect added types
+    const addedTypes = [];
+    collectFromMap(defensiveAbilities.addType, abilities, (type) => {
+        if (!defTypes.includes(type) && !addedTypes.includes(type)) addedTypes.push(type);
+    });
+
+    // Collect immunities
+    const immuneTo = [];
+    collectFromMap(defensiveAbilities.immunity, abilities, (types) => immuneTo.push(...types));
+
+    // Collect type multipliers (resist, quad resist, weakness, weakness4x — all unified)
+    const typeMults = {};
+    collectFromMap(defensiveAbilities.typeMultipliers, abilities, (map) => {
+        for (const [type, mult] of Object.entries(map)) {
+            const baseType = type.split(" ")[0]; // "Fire (if Grass-type)" -> "Fire"
+            typeMults[baseType] = (typeMults[baseType] || 1) * mult;
+        }
+    });
+
+    // Calculate type effectiveness
+    const allDefTypes = [...defTypes, ...addedTypes];
+    const attackTypes = getUsableTypes();
+    const coverage = {};
+
+    for (const atkT of attackTypes) {
+        let eff = 1;
+        if (immuneTo.includes(atkT)) {
+            eff = 0;
+        } else {
+            for (const defT of allDefTypes) {
+                eff *= getTypeEffectiveness(atkT, defT);
+            }
+            if (typeMults[atkT] !== undefined) eff *= typeMults[atkT];
+        }
+        (coverage[eff] ??= []).push(atkT);
+    }
+
+    // Calculate Physical / Special / Contact damage multipliers
+    const dmgMods = { Physical: 100, Special: 100, Contact: 100 };
+    collectFromMap(defensiveAbilities.dmgCategory, abilities, (map) => {
+        for (const [cat, mult] of Object.entries(map)) {
+            if (dmgMods[cat] !== undefined) dmgMods[cat] *= mult;
+        }
+    });
+
+    // Build ability effect summaries
+    const abiEffects = buildAbiEffects(abilities);
+
+    renderResult(coverage, defTypes, addedTypes, abiEffects, dmgMods);
+}
+
+// --- Effect Summary ---
+
+// Each entry: [category key, formatter function]
+const effectFormatters = [
+    ["addType", (v) => `+${v} type`],
+    ["immunity", (v) => `immune: ${v.join(", ")}`],
+    ["statBoost", (v) => `stat boost: ${v.join(", ")}`],
+    ["nullWeakness", (v) => `null weakness: ${v.join(", ")}`],
+    ["typeMultipliers", (v) => Object.entries(v).map(([t, m]) => `x${m}: ${t}`).join(" | ")],
+    ["dmgCategory", (v) => {
+        const entries = Object.entries(v);
+        const allSame = entries.length > 1 && entries.every(([, m]) => m === entries[0][1]);
+        if (allSame) return `x${entries[0][1]}: All moves`;
+        return entries.map(([cat, m]) => `x${m}: ${cat} moves`).join(" | ");
+    }],
+    ["resistSE", (v) => `x${v}: SE moves`],
+];
+
+function buildAbiEffects(abilities) {
+    const results = [];
+    for (const abi of abilities) {
+        const effects = [];
+        for (const [key, fmt] of effectFormatters) {
+            const val = defensiveAbilities[key][abi];
+            if (val) effects.push(fmt(val));
+        }
+        if (effects.length) results.push({ name: abi, effects });
+    }
+    return results;
+}
+
+// --- Render ---
+
+function renderResult(coverage, baseTypes, addedTypes, abiEffects, dmgMods) {
+    const container = $("#typecalc-result");
+    container.empty();
+
+    // Effective typing row
+    const infoRow = e("div", "typecalc-info-row");
+    for (const t of baseTypes) {
+        const badge = e("div", `${t.toLowerCase()} type`);
+        badge.append(e("span", "span-align", t));
+        infoRow.append(badge);
+    }
+    for (const t of addedTypes) {
+        const badge = e("div", `${t.toLowerCase()} type`);
+        badge.append(e("span", "span-align", "+" + t));
+        infoRow.append(badge);
+    }
+    container.append(infoRow);
+
+    // Ability effect rows
+    abiEffects.forEach((abi, i) => {
+        const row = e("div", "typecalc-abi-info");
+        row.append(e("div", "typecalc-abi-name color" + (i % 2 ? "A" : "B"), abi.name));
+        row.append(e("div", "typecalc-abi-effects color" + (i % 2 ? "C" : "D"), abi.effects.join(" | ")));
+        container.append(row);
+    });
+
+    // Physical / Special / Contact modifiers
+    const modRow = e("div", "typecalc-dmg-mods");
+    for (const cat of ["Physical", "Special", "Contact"]) {
+        const pct = dmgMods[cat];
+        const mod = e("div", "typecalc-dmg-mod");
+        mod.append(e("div", "typecalc-dmg-label", cat));
+        const valClass = pct < 100 ? "typecalc-dmg-val resist" : "typecalc-dmg-val";
+        mod.append(e("div", valClass, Math.round(pct) + "%"));
+        modRow.append(mod);
+    }
+    container.append(modRow);
+
+    // Coverage rows
+    const frag = document.createDocumentFragment();
+    for (const mult of Object.keys(coverage).sort((a, b) => Number(a) - Number(b))) {
+        const row = e("div", "typecalc-coverage-row");
+        const mulDiv = e("div", "typecalc-coverage-mul");
+        mulDiv.append(e("span", "span-align", mult));
+        row.append(mulDiv);
+
+        const typeList = e("div", "typecalc-coverage-list");
+        for (const type of coverage[mult]) {
+            const colorDiv = e("div", `${type.toLowerCase()} type`);
+            colorDiv.append(e("span", "span-align", type.substr(0, 5)));
+            typeList.append(colorDiv);
+        }
+        row.append(typeList);
+        frag.append(row);
+    }
+    container.append(frag);
+}

--- a/static/js/panels/typecalc_panel.js
+++ b/static/js/panels/typecalc_panel.js
@@ -2,7 +2,7 @@ import { gameData } from "../data_version.js";
 import { e } from "../utils.js";
 import { getTypeEffectiveness } from "../weakness.js";
 
-import defensiveAbilities from "../data/defensiveAbilities.js";
+import defensiveAbilities from "../defensiveAbilities.js";
 
 // Build sorted list of all defensive ability names
 function getAllDefensiveAbilityNames() {

--- a/static/js/panels/typecalc_panel.js
+++ b/static/js/panels/typecalc_panel.js
@@ -2,177 +2,29 @@ import { gameData } from "../data_version.js";
 import { e } from "../utils.js";
 import { getTypeEffectiveness } from "../weakness.js";
 
-// All defensive abilities grouped by effect type
-const defensiveAbilities = {
-    // Immunity: nullify damage from type entirely
-    immunity: {
-        "Flash Fire": ["Fire"],
-        "Sap Sipper": ["Grass"],
-        "Volt Absorb": ["Electric"],
-        "Lightning Rod": ["Electric"],
-        "Motor Drive": ["Electric"],
-        "Water Absorb": ["Water"],
-        "Dry Skin": ["Water"],
-        "Storm Drain": ["Water"],
-        "Evaporate": ["Water"],
-        "Levitate": ["Ground"],
-        "Dragonfly": ["Ground"],
-        "Mountaineer": ["Rock"],
-        "Poison Absorb": ["Poison"],
-        "Aerodynamics": ["Flying"],
-        "Well Baked Body": ["Fire"],
-        "Elemental Vortex": ["Fire", "Water"],
-        "Justified": ["Dark"],
-        "Ice Dew": ["Ice"],
-        "Earth Eater": ["Ground"],
-        "Hover": ["Ground"],
-        "Aerialist": ["Ground"],
-        "Imposing Wings": ["Ground"],
-        "Desolate Sun": ["Ground", "Water"],
-        "Reservoir": ["Water"],
-        "Desolate Land": ["Water"],
-        "Primordial Sea": ["Fire"],
-        "Fey Flight": ["Ground"],
-        "Radiance": ["Dark"],
-        "Heat Sink": ["Fire"],
-    },
-    // Adds a defensive type
-    addType: {
-        "Phantom": "Ghost",
-        "Metallic": "Steel",
-        "Dragonfly": "Dragon",
-        "Half Drake": "Dragon",
-        "Ice Age": "Ice",
-        "Grounded": "Ground",
-        "Aquatic": "Water",
-        "Turboblaze": "Fire",
-        "Teravolt": "Electric",
-        "Fairy Tale": "Fairy",
-        "Aquatic Dweller": "Water",
-        "Metallic Jaws": "Steel",
-        "Bruiser": "Fighting",
-        "Rocky Exterior": "Rock",
-        "Lightning Born": "Electric",
-        "Komodo": "Dragon",
-        "Fey Flight": "Fairy",
-        "Dead Bark": "Ghost",
-        "Lightsaber": "Fire",
-        "Hover": "Psychic",
-        "Ominous Shroud": "Ghost",
-        "Voltron": "Steel",
-        "Waterborne": "Water",
-        "Atlantic Ruler": "Water",
-        "Draconic Might": "Dragon",
-        "Dragonfruit": "Dragon",
-        "Witch Broom": "Psychic",
-        "Rock Armor": "Rock",
-    },
-    // Type-based multipliers: { ability: { type: multiplier } }
-    typeMultipliers: {
-        // x0.5 resists
-        "Water Bubble": { "Fire": 0.5 },
-        "Seaweed": { "Fire (if Grass-type)": 0.5 },
-        "Heatproof": { "Fire": 0.5 },
-        "Iron Giant": { "Fire": 0.5 },
-        "Thick Fat": { "Fire": 0.5, "Ice": 0.5 },
-        "Immunity": { "Poison": 0.5 },
-        "Fossilized": { "Rock": 0.5 },
-        "Raw Wood": { "Grass": 0.5 },
-        "Water Compaction": { "Water": 0.5 },
-        "Old Mariner": { "Fire": 0.5 },
-        "Flame Bubble": { "Fire": 0.5 },
-        "Deep Freeze": { "Fire": 0.5 },
-        "Droideka": { "Fire": 0.5 },
-        "Thermal Entropy": { "Fire": 0.5 },
-        "Strong Foundation": { "Water": 0.5, "Ground": 0.5 },
-        "Sumo Guard": { "Fire": 0.5, "Ice": 0.5 },
-        "Tummyache": { "Fire": 0.5, "Ice": 0.5 },
-        "Purifying Salt": { "Ghost": 0.5 },
-        "Heavy Metal": { "Ghost": 0.5, "Dark": 0.5 },
-        "Aegis Ward": { "Dark": 0.5, "Ghost": 0.5, "Psychic": 0.5 },
-        "Elemental Aegis": { "Fire": 0.5, "Electric": 0.5, "Water": 0.5 },
-        "Magma Armor": { "Water": 0.5, "Ice": 0.5 },
-        "Hyper Cleanse": { "Poison": 0.5 },
-        // x0.25 quad resists
-        "Thick Blubber": { "Fire": 0.25, "Ice": 0.25 },
-        // x2 weaknesses
-        "Fluffy": { "Fire": 2 },
-        "Puffy": { "Fire": 2 },
-        "Liquified": { "Water": 2 },
-        "Dry Skin": { "Fire": 2 },
-        "Massive Pelt": { "Fire": 2 },
-        // x4 weaknesses
-        "Fluffiest": { "Fire": 4 },
-    },
-    // Damage category modifiers: { ability: { Physical, Special, Contact } multiplier }
-    dmgCategory: {
-        "Fur Coat": { Physical: 0.5 },
-        "Apple Enlightenment": { Physical: 0.5 },
-        "Prismatic Fur": { Physical: 0.5, Special: 0.5 },
-        "Ice Scales": { Special: 0.5 },
-        "Fire Scales": { Special: 0.5 },
-        "Rainbow Scales": { Special: 0.5 },
-        "Fluffy": { Contact: 0.5 },
-        "Puffy": { Contact: 0.5 },
-        "Massive Pelt": { Contact: 0.5 },
-        "Liquified": { Contact: 0.5 },
-        "Fluffiest": { Contact: 0.25 },
-        "Ice Plumes": { Special: 0.5 },
-        "Prism Scales": { Special: 0.7 },
-        "Sand Guard": { "Special (in sand)": 0.5 },
-        "Sun Basking": { "Physical (in sun)": 0.5 },
-        // General damage reduction (all categories)
-        "Dead Bark": { Physical: 0.85, Special: 0.85, Contact: 0.85 },
-        "Rock Armor": { Physical: 0.9, Special: 0.9, Contact: 0.9 },
-        "Battle Armor": { Physical: 0.8, Special: 0.8, Contact: 0.8 },
-        "Shell Armor": { Physical: 0.8, Special: 0.8, Contact: 0.8 },
-        "Dream State": { Physical: 0.8, Special: 0.8, Contact: 0.8 },
-        "Crust Coat": { Physical: 0.8, Special: 0.8, Contact: 0.8 },
-        "Parry": { Physical: 0.8, Special: 0.8, Contact: 0.8 },
-        "Deflect": { Physical: 0.8, Special: 0.8, Contact: 0.8 },
-        "Feathercoat": { Physical: 0.9, Special: 0.9, Contact: 0.9 },
-        "Mucus Membrane": { Physical: 0.7, Special: 0.7, Contact: 0.7 },
-        // Combos inheriting Shell Armor / Battle Armor (20% less)
-        "Faraday Cage": { Physical: 0.8, Special: 0.8, Contact: 0.8 },
-        "Toxic Shell": { Physical: 0.8, Special: 0.8, Contact: 0.8 },
-        "Shattered Armor": { Physical: 0.8, Special: 0.8, Contact: 0.8 },
-        "Fortress": { Physical: 0.8, Special: 0.8, Contact: 0.8 },
-    },
-    // Stat boost when hit by type (informational only)
-    statBoost: {
-        "Cryo Architect": ["Water", "Ice"],
-    },
-    // Nullifies weakness to types (informational only)
-    nullWeakness: {
-        "Gifted Mind": ["Ghost", "Bug", "Dark"],
-    },
-    // Reduces super-effective damage (informational — affects all SE types)
-    resistSE: {
-        "Filter": 0.65,
-        "Solid Rock": 0.65,
-        "Prism Armor": 0.65,
-        "Permafrost": 0.65,
-        "Thick Skin": 0.65,
-        "Flame Shield": 0.65,
-        "Primal Armor": 0.5,
-        "Refrigerator": 0.65,
-        "Fortress": 0.65,
-    },
-};
+import defensiveAbilities from "../data/defensiveAbilities.js";
 
 // Build sorted list of all defensive ability names
 function getAllDefensiveAbilityNames() {
     const names = new Set();
-    for (const category of Object.values(defensiveAbilities)) {
-        for (const name of Object.keys(category)) names.add(name);
+    for (const [name, entry] of Object.entries(defensiveAbilities.effects)) {
+        // Skip if ability only has weather/terrain conditionals
+        if (!entry.resists && !entry.addedType) {
+            const onlyWeatherTerrain = (entry.conditionalResistances || []).every(
+                (cr) => cr.condition.type === "weather" || cr.condition.type === "terrain"
+            );
+            if (onlyWeatherTerrain) continue;
+        }
+        names.add(name);
     }
     return [...names].sort();
 }
 
 const defensiveAbilityNames = getAllDefensiveAbilityNames();
+const DMG_CATEGORIES = new Set(["Physical", "Special", "Contact"]);
 
 // Helper: collect values from a map category for selected abilities
-function collectFromMap(category, abilities, collector) {
+function forEachAbilityIn(category, abilities, collector) {
     for (const abi of abilities) {
         const val = category[abi];
         if (val) collector(val, abi);
@@ -223,20 +75,20 @@ function setupDropdown(btnId, options) {
     function selectOption(opt) {
         btn.val(opt.label);
         btn[0].dataset.value = opt.value;
-        close();
+        closeList();
         btn[0].blur();
         updateReadonly();
         recalculate();
     }
 
-    function open(filter) {
+    function openList(filter) {
         closeAllDropdowns();
         buildList(filter);
         list.show();
         dropdownStates[btnId].isOpen = true;
     }
 
-    function close() {
+    function closeList() {
         list.hide();
         dropdownStates[btnId].isOpen = false;
     }
@@ -251,13 +103,13 @@ function setupDropdown(btnId, options) {
     btn.off("focus").on("focus", () => {
         if (btn[0].readOnly) return;
         btn.val("");
-        open("");
+        openList("");
     });
 
-    btn.off("input").on("input", () => open(btn.val()));
+    btn.off("input").on("input", () => openList(btn.val()));
 
     btn.off("blur").on("blur", () => {
-        close();
+        closeList();
         const match = options.find((o) => o.value === btn[0].dataset.value);
         btn.val(match ? match.label : "-- None --");
     });
@@ -265,7 +117,7 @@ function setupDropdown(btnId, options) {
     btn.off("mousedown").on("mousedown", (ev) => {
         if (dropdownStates[btnId].isOpen) {
             ev.preventDefault();
-            close();
+            closeList();
             btn[0].blur();
             return;
         }
@@ -274,7 +126,7 @@ function setupDropdown(btnId, options) {
             btn[0].readOnly = false;
             btn.val("");
             btn[0].focus();
-            open("");
+            openList("");
         }
     });
 }
@@ -293,9 +145,9 @@ export function populateTypeCalc() {
     setupDropdown("typecalc-type2", [noneOption, ...typeOptions]);
     $("#typecalc-type2")[0].dataset.value = "";
 
-    const abiOptions = [noneOption, ...defensiveAbilityNames.map((n) => ({ label: n, value: n }))];
+    const abilityOptions = [noneOption, ...defensiveAbilityNames.map((n) => ({ label: n, value: n }))];
     for (let i = 0; i < 4; i++) {
-        setupDropdown(`typecalc-abi${i}`, abiOptions);
+        setupDropdown(`typecalc-abi${i}`, abilityOptions);
         $(`#typecalc-abi${i}`)[0].dataset.value = "";
     }
 
@@ -333,76 +185,105 @@ function recalculate() {
 
     const abilities = getSelectedAbilities();
 
-    // Collect added types
+    // Collect added types from effects
     const addedTypes = [];
-    collectFromMap(defensiveAbilities.addType, abilities, (type) => {
-        if (!defTypes.includes(type) && !addedTypes.includes(type)) addedTypes.push(type);
+    forEachAbilityIn(defensiveAbilities.effects, abilities, (entry) => {
+        if (entry.addedType && !defTypes.includes(entry.addedType) && !addedTypes.includes(entry.addedType)) {
+            addedTypes.push(entry.addedType);
+        }
     });
 
-    // Collect immunities
-    const immuneTo = [];
-    collectFromMap(defensiveAbilities.immunity, abilities, (types) => immuneTo.push(...types));
+    // Collect all resist modifiers from unified effects map
+    const typeMultipliers = {};
+    const dmgMods = { Physical: 100, Special: 100, Contact: 100 };
+    const allDefTypes = [...defTypes, ...addedTypes];
+    const attackTypes = getUsableTypes();
 
-    // Collect type multipliers (resist, quad resist, weakness, weakness4x — all unified)
-    const typeMults = {};
-    collectFromMap(defensiveAbilities.typeMultipliers, abilities, (map) => {
-        for (const [type, mult] of Object.entries(map)) {
-            const baseType = type.split(" ")[0]; // "Fire (if Grass-type)" -> "Fire"
-            typeMults[baseType] = (typeMults[baseType] || 1) * mult;
+    function applyResistance(resistances) {
+        for (const r of resistances) {
+            if (DMG_CATEGORIES.has(r.damageSource)) {
+                dmgMods[r.damageSource] *= r.multiplier;
+            } else if (r.damageSource !== "SE") {
+                // TODO: apply SE resist to calculation
+                typeMultipliers[r.damageSource] = (typeMultipliers[r.damageSource] ?? 1) * r.multiplier;
+            }
+        }
+    }
+
+    forEachAbilityIn(defensiveAbilities.effects, abilities, (entry) => {
+        if (entry.resists) applyResistance(entry.resists);
+        if (entry.conditionalResistances) {
+            for (const cr of entry.conditionalResistances) {
+                if (cr.condition.type === "type" && allDefTypes.includes(cr.condition.value)) {
+                    applyResistance(cr.resistance);
+                }
+                // TODO: add weather/terrain conditional resistance calcualtion
+            }
         }
     });
 
     // Calculate type effectiveness
-    const allDefTypes = [...defTypes, ...addedTypes];
-    const attackTypes = getUsableTypes();
     const coverage = {};
 
     for (const atkT of attackTypes) {
         let eff = 1;
-        if (immuneTo.includes(atkT)) {
-            eff = 0;
-        } else {
-            for (const defT of allDefTypes) {
-                eff *= getTypeEffectiveness(atkT, defT);
-            }
-            if (typeMults[atkT] !== undefined) eff *= typeMults[atkT];
+        for (const defT of allDefTypes) {
+            eff *= getTypeEffectiveness(atkT, defT);
         }
+        if (typeMultipliers[atkT] !== undefined) eff *= typeMultipliers[atkT];
         (coverage[eff] ??= []).push(atkT);
     }
 
-    // Calculate Physical / Special / Contact damage multipliers
-    const dmgMods = { Physical: 100, Special: 100, Contact: 100 };
-    collectFromMap(defensiveAbilities.dmgCategory, abilities, (map) => {
-        for (const [cat, mult] of Object.entries(map)) {
-            if (dmgMods[cat] !== undefined) dmgMods[cat] *= mult;
-        }
-    });
-
     // Build ability effect summaries
-    const abiEffects = buildAbiEffects(abilities);
+    const abilityEffects = buildAbilityEffects(abilities);
 
-    renderResult(coverage, defTypes, addedTypes, abiEffects, dmgMods);
+    renderResult(coverage, defTypes, addedTypes, abilityEffects, dmgMods);
 }
 
 // --- Effect Summary ---
 
-// Each entry: [category key, formatter function]
+function formatResistance(resistances) {
+    const typeResists = resistances.filter((r) => !DMG_CATEGORIES.has(r.damageSource));
+    const dmgResists = resistances.filter((r) => DMG_CATEGORIES.has(r.damageSource));
+    const parts = [];
+    if (typeResists.length) {
+        const sorted = [...typeResists].sort((a, b) => a.multiplier - b.multiplier);
+        for (const r of sorted) {
+            let text = r.multiplier === 0 ? `${r.damageSource} immune` : `${r.damageSource} x ${r.multiplier}`;
+            if (r.bonusEffect) text += `, ${r.bonusEffect}`;
+            parts.push(text);
+        }
+    }
+    if (dmgResists.length) {
+        const allSame = dmgResists.length > 1 && dmgResists.every((r) => r.multiplier === dmgResists[0].multiplier);
+        if (allSame) {
+            parts.push(`All moves x ${dmgResists[0].multiplier}`);
+        } else {
+            for (const r of dmgResists) {
+                let text = `${r.damageSource} moves x ${r.multiplier}`;
+                if (r.bonusEffect) text += `, ${r.bonusEffect}`;
+                parts.push(text);
+            }
+        }
+    }
+    return parts.join(" | ");
+}
+
 const effectFormatters = [
-    ["addType", (v) => `+${v} type`],
-    ["immunity", (v) => `immune: ${v.join(", ")}`],
-    ["statBoost", (v) => `stat boost: ${v.join(", ")}`],
-    ["nullWeakness", (v) => `null weakness: ${v.join(", ")}`],
-    ["typeMultipliers", (v) => Object.entries(v).map(([t, m]) => `x${m}: ${t}`).join(" | ")],
-    ["dmgCategory", (v) => {
-        const entries = Object.entries(v);
-        const allSame = entries.length > 1 && entries.every(([, m]) => m === entries[0][1]);
-        if (allSame) return `x${entries[0][1]}: All moves`;
-        return entries.map(([cat, m]) => `x${m}: ${cat} moves`).join(" | ");
+    ["effects", (v) => {
+        const parts = [];
+        if (v.addedType) parts.push(`+${v.addedType} type`);
+        if (v.resists) parts.push(formatResistance(v.resists));
+        if (v.conditionalResistances) {
+            for (const cr of v.conditionalResistances) {
+                parts.push(`${formatResistance(cr.resistance)} (if ${cr.condition.value})`);
+            }
+        }
+        return parts.join(" | ");
     }],
-    ["resistSE", (v) => `x${v}: SE moves`],
 ];
 
-function buildAbiEffects(abilities) {
+function buildAbilityEffects(abilities) {
     const results = [];
     for (const abi of abilities) {
         const effects = [];
@@ -416,8 +297,8 @@ function buildAbiEffects(abilities) {
 }
 
 // --- Render ---
-
-function renderResult(coverage, baseTypes, addedTypes, abiEffects, dmgMods) {
+// TODO: add weather/terrain selector for global type modifiers and apply conditional resistances calcualtion
+function renderResult(coverage, baseTypes, addedTypes, abilityEffects, dmgMods) {
     const container = $("#typecalc-result");
     container.empty();
 
@@ -436,7 +317,7 @@ function renderResult(coverage, baseTypes, addedTypes, abiEffects, dmgMods) {
     container.append(infoRow);
 
     // Ability effect rows
-    abiEffects.forEach((abi, i) => {
+    abilityEffects.forEach((abi, i) => {
         const row = e("div", "typecalc-abi-info");
         row.append(e("div", "typecalc-abi-name color" + (i % 2 ? "A" : "B"), abi.name));
         row.append(e("div", "typecalc-abi-effects color" + (i % 2 ? "C" : "D"), abi.effects.join(" | ")));
@@ -445,12 +326,12 @@ function renderResult(coverage, baseTypes, addedTypes, abiEffects, dmgMods) {
 
     // Physical / Special / Contact modifiers
     const modRow = e("div", "typecalc-dmg-mods");
-    for (const cat of ["Physical", "Special", "Contact"]) {
-        const pct = dmgMods[cat];
+    for (const category of ["Physical", "Special", "Contact"]) {
+        const percentage = dmgMods[category];
         const mod = e("div", "typecalc-dmg-mod");
-        mod.append(e("div", "typecalc-dmg-label", cat));
-        const valClass = pct < 100 ? "typecalc-dmg-val resist" : "typecalc-dmg-val";
-        mod.append(e("div", valClass, Math.round(pct) + "%"));
+        mod.append(e("div", "typecalc-dmg-label", category));
+        const valClass = percentage < 100 ? "typecalc-dmg-val resist" : "typecalc-dmg-val";
+        mod.append(e("div", valClass, Math.round(percentage) + "%"));
         modRow.append(mod);
     }
     container.append(modRow);

--- a/static/js/sidebar.js
+++ b/static/js/sidebar.js
@@ -1,25 +1,25 @@
-import { search, updateMainSearchKey} from "./search.js"
+import { search, updateMainSearchKey } from "./search.js"
 import { activateSearch } from "./filters.js"
 import { capitalizeFirstLetter } from "./utils.js"
 import { getHintInteractibilityClass } from "./settings.js"
 
-export function setupPanels(){
+export function setupPanels() {
     // if modified sync it with "search.js > search > panelUpdatesTable" variable
     const panelTable = [
         ["#btn-species", "#panel-species", "#species-data", "#builder-data"],
-        ["#btn-abis", "#panel-abis"],
+        ["#btn-abis", "#panel-abis", "#abis-list", "#typecalc-data"],
         ["#btn-moves", "#panel-moves"],
         ["#btn-locations", "#panel-locations"],
         ["#btn-trainers", "#panel-trainers"]
     ]
-    
-    for (const i in panelTable){
+
+    for (const i in panelTable) {
         const btnPanel = panelTable[i]
-        $(btnPanel[0]).on('click', ()=>{
+        $(btnPanel[0]).on('click', () => {
             const curBtn = $('aside .btn-active')
             const btn = $(btnPanel[0])
             const panel = $(btnPanel[1])
-            if (curBtn[0] === btn[0]){
+            if (curBtn[0] === btn[0]) {
                 if (!btnPanel[2]) return
                 // modify the button inner text
                 const small = btn.find('.small-select')
@@ -35,7 +35,7 @@ export function setupPanels(){
 
             curBtn.addClass('btn-n-active')
             curBtn.removeClass('btn-active')
-            
+
             btn.removeClass('btn-n-active')
             btn.addClass('btn-active')
 
@@ -44,11 +44,11 @@ export function setupPanels(){
             curPan.toggle()
             panel.addClass('active-panel')
             panel.toggle()
-            
+
             // tell the search only to update this
             search.panelUpdatesIndex = i
             //if an update was caused when this pannel was frozen
-            if (search.panelFrozenUpdate[i]){
+            if (search.panelFrozenUpdate[i]) {
                 search.defrosting = false
                 fastdom.mutate(() => {
                     //then refresh in the next frame


### PR DESCRIPTION
## Summary
- Adds a **Type Defense Calculator** as a sub-tab under Abilities (toggles like Species/Builder)
- Users select **2 types** + up to **4 defensive abilities** to calculate type matchups
- Displays type coverage chart, ability effect info rows, and Physical/Special/Contact damage % modifiers

## Features
- Custom searchable dropdowns with type-to-filter, matching app design (basis33 font, theme colors, alternating colorA/B rows)
- Coverage chart reuses the same style as species panel defensive coverage
- Supports **119 defensive abilities** with unified `AbilityEffect` interface:
  - **Immunity** — nullify type damage (Flash Fire, Levitate, Gifted Mind, etc.)
  - **Type-adding** — adds defensive type (Phantom, Metallic, Dragonfly, etc.)
  - **Type multipliers** — resist/weakness to types (Thick Fat, Dry Skin, Fluffy, etc.)
  - **Damage category** — Physical/Special/Contact reduction (Fur Coat, Ice Scales, Battle Armor, etc.)
  - **SE reduction** — reduces super-effective damage (Filter, Solid Rock, Primal Armor, etc.)
  - **Conditional** — type-based (Steelworker if Steel, Seaweed if Grass) and weather-based (Sand Guard, Dune Terror, Christmas Spirit, etc.)
  - **Bonus effects** — on-hit effects displayed inline (heals, stat boosts, redirects)
- All ability data verified against gameDataV2.65beta.json (1033 abilities)
- Weather/terrain-only abilities pre-loaded in data but filtered from UI until weather selector is added

## TODO
- Weather/terrain selector to apply conditional resistances and global type modifiers
- SE resist applied to actual type chart calculation